### PR TITLE
Update to aas-core-meta, codegen, testgen 44756fb, e2b793f, bf3720d7

### DIFF
--- a/dev_scripts/aas_core3/__init__.py
+++ b/dev_scripts/aas_core3/__init__.py
@@ -3,5 +3,5 @@ Provide Python SDK as copied from aas-core-codegen test data.
 
 This copy is necessary so that we can decouple from ``aas-core*-python`` repository.
 
-The revision of aas-core-codegen was: a8a510e
+The revision of aas-core-codegen was: e2b793f
 """

--- a/dev_scripts/aas_core3/types.py
+++ b/dev_scripts/aas_core3/types.py
@@ -680,10 +680,6 @@ class Qualifiable(Class):
     The value of a qualifiable element may be further qualified by one or more
     qualifiers.
 
-    .. note::
-
-        This constraint is checked at :py:class:`Submodel`.
-
     :constraint AASd-119:
         .. _constraint_AASd-119:
 
@@ -691,6 +687,10 @@ class Qualifiable(Class):
         equal to :py:attr:`QualifierKind.TEMPLATE_QUALIFIER` and the qualified element
         inherits from :py:class:`HasKind` then the qualified element shall be of
         kind Template (:py:attr:`HasKind.kind` = :py:attr:`ModellingKind.TEMPLATE`).
+
+        .. note::
+
+            This constraint is checked at :py:class:`Submodel`.
     """
 
     #: Additional qualification of a qualifiable element.
@@ -1063,28 +1063,28 @@ class AssetInformation(Class):
     does not already exist, the corresponding attribute :py:attr:`global_asset_id` is
     optional.
 
-    .. note::
-
-        :ref:`Constraint AASd-116 <constraint_AASd-116>` is important to enable a generic search across global
-        and specific asset IDs.
-
-    .. note::
-
-        In the book, :ref:`Constraint AASd-116 <constraint_AASd-116>` imposes a
-        case-insensitive equality against ``globalAssetId``. This is
-        culturally-dependent, and depends on the system settings.
-        For example, the case-folding for the letters "i" and "I" is
-        different in Turkish from English.
-
-        We implement the constraint as case-sensitive instead to allow
-        for interoperability across different culture settings.
-
     :constraint AASd-116:
         .. _constraint_AASd-116:
 
         ``globalAssetId`` is a reserved key. If used as value for
         :py:attr:`SpecificAssetID.name` then :py:attr:`SpecificAssetID.value` shall be
         identical to :py:attr:`global_asset_id`.
+
+        .. note::
+
+            :ref:`Constraint AASd-116 <constraint_AASd-116>` is important to enable a generic search across
+            global and specific asset IDs.
+
+        .. note::
+
+            In the book, :ref:`Constraint AASd-116 <constraint_AASd-116>` imposes a
+            case-insensitive equality against ``globalAssetId``. This is
+            culturally-dependent, and depends on the system settings.
+            For example, the case-folding for the letters "i" and "I" is
+            different in Turkish from English.
+
+            We implement the constraint as case-sensitive instead to allow
+            for interoperability across different culture settings.
 
     :constraint AASd-131:
         .. _constraint_AASd-131:
@@ -4585,25 +4585,60 @@ class ConceptDescription(Identifiable, HasDataSpecification):
     The description of the concept should follow a standardized schema (realized as
     data specification template).
 
-    .. note::
+    :constraint AASc-3a-004:
+        .. _constraint_AASc-3a-004:
 
-        Note: categories are deprecated since V3.0 of Part 1a of the document series
-        "Details of the Asset Administration Shell".
+        For a :py:class:`ConceptDescription` with :py:attr:`category` ``PROPERTY`` or
+        ``VALUE`` using data specification IEC61360,
+        the :py:attr:`DataSpecificationIEC61360.data_type` is mandatory and shall be
+        one of: ``DATE``, ``STRING``, ``STRING_TRANSLATABLE``, ``INTEGER_MEASURE``,
+        ``INTEGER_COUNT``, ``INTEGER_CURRENCY``, ``REAL_MEASURE``, ``REAL_COUNT``,
+        ``REAL_CURRENCY``, ``BOOLEAN``, ``RATIONAL``, ``RATIONAL_MEASURE``,
+        ``TIME``, ``TIMESTAMP``.
 
-    .. note::
+        .. note::
 
-        Note: categories are deprecated since V3.0 of Part 1a of the document series
-        "Details of the Asset Administration Shell".
+            Note: categories are deprecated since V3.0 of Part 1a of the document series
+            "Details of the Asset Administration Shell".
 
-    .. note::
+    :constraint AASc-3a-005:
+        .. _constraint_AASc-3a-005:
 
-        Categories are deprecated since V3.0 of Part 1a of the document series
-        "Details of the Asset Administration Shell".
+        For a :py:class:`ConceptDescription` with :py:attr:`category` ``REFERENCE``
+        using data specification template IEC61360,
+        the :py:attr:`DataSpecificationIEC61360.data_type` shall be
+        one of: ``STRING``, ``IRI``, ``IRDI``.
 
-    .. note::
+        .. note::
 
-        Categories are deprecated since V3.0 of Part 1a of the document series
-        "Details of the Asset Administration Shell".
+            Note: categories are deprecated since V3.0 of Part 1a of the document series
+            "Details of the Asset Administration Shell".
+
+    :constraint AASc-3a-006:
+        .. _constraint_AASc-3a-006:
+
+        For a :py:class:`ConceptDescription` with :py:attr:`category` ``DOCUMENT``
+        using data specification IEC61360,
+        the :py:attr:`DataSpecificationIEC61360.data_type` shall be one of ``FILE``,
+        ``BLOB``, ``HTML``
+
+        .. note::
+
+            Categories are deprecated since V3.0 of Part 1a of the document series
+            "Details of the Asset Administration Shell".
+
+    :constraint AASc-3a-007:
+        .. _constraint_AASc-3a-007:
+
+        For a :py:class:`ConceptDescription` with :py:attr:`category` ``QUALIFIER_TYPE``
+        using data specification IEC61360,
+        the :py:attr:`DataSpecificationIEC61360.data_type` is mandatory and shall be
+        defined.
+
+        .. note::
+
+            Categories are deprecated since V3.0 of Part 1a of the document series
+            "Details of the Asset Administration Shell".
 
     :constraint AASc-3a-008:
         .. _constraint_AASc-3a-008:
@@ -6189,20 +6224,6 @@ class DataSpecificationIEC61360(DataSpecificationContent):
 
     .. note::
 
-        It is also possible that both :py:attr:`value` and :py:attr:`value_list` are empty.
-        This is the case for concept descriptions that define the semantics of a
-        property but do not have an enumeration (:py:attr:`value_list`) as data type.
-
-    .. note::
-
-        Although it is possible to define a :py:class:`ConceptDescription` for a
-        :attr:´value_list`,
-        it is not possible to reuse this :py:attr:`value_list`.
-        It is only possible to directly add a :py:attr:`value_list` as data type
-        to a specific semantic definition of a property.
-
-    .. note::
-
         IEC61360 requires also a globally unique identifier for a concept
         description. This ID is not part of the data specification template.
         Instead the :py:attr:`ConceptDescription.id` as inherited via
@@ -6217,6 +6238,27 @@ class DataSpecificationIEC61360(DataSpecificationContent):
         :py:attr:`ConceptDescription.display_name` and
         :py:attr:`preferred_name`. Same holds for
         :py:attr:`ConceptDescription.description` and :py:attr:`definition`.
+
+    :constraint AASc-3a-010:
+        .. _constraint_AASc-3a-010:
+
+        If :py:attr:`value` is not empty then :py:attr:`value_list` shall be empty
+        and vice versa.
+
+        .. note::
+
+            It is also possible that both :py:attr:`value` and :py:attr:`value_list` are
+            empty. This is the case for concept descriptions that define the semantics
+            of a property but do not have an enumeration (:py:attr:`value_list`) as
+            data type.
+
+        .. note::
+
+            Although it is possible to define a :py:class:`ConceptDescription` for a
+            :attr:´value_list`,
+            it is not possible to reuse this :py:attr:`value_list`.
+            It is only possible to directly add a :py:attr:`value_list` as data type
+            to a specific semantic definition of a property.
 
     :constraint AASc-3a-009:
         .. _constraint_AASc-3a-009:

--- a/dev_scripts/aas_core3/verification.py
+++ b/dev_scripts/aas_core3/verification.py
@@ -2439,7 +2439,8 @@ class _Transformer(
                         specific_asset_id.name != 'globalAssetId'
                         or (
                             (
-                                specific_asset_id.name == 'globalAssetId'
+                                (that.global_asset_id is not None)
+                                and specific_asset_id.name == 'globalAssetId'
                                 and specific_asset_id.value == that.global_asset_id
                             )
                         )
@@ -2784,7 +2785,7 @@ class _Transformer(
         if not (
             not (that.submodel_elements is not None)
             or (
-                not (that.kind != aas_types.ModellingKind.TEMPLATE)
+                not (that.kind_or_default() != aas_types.ModellingKind.TEMPLATE)
                 or (
                     all(
                         not (submodel_element.qualifiers is not None)
@@ -8085,7 +8086,7 @@ class _Transformer(
         if not (
             not (
                 (
-                    (that.data_type is None)
+                    (that.data_type is not None)
                     and (that.data_type in aas_constants.IEC_61360_DATA_TYPES_WITH_UNIT)
                 )
             )

--- a/dev_scripts/setup.py
+++ b/dev_scripts/setup.py
@@ -28,8 +28,8 @@ setup(
     keywords="asset administration shell code generation industry 4.0 industrie i4.0",
     packages=find_packages(exclude=["tests", "continuous_integration", "dev_scripts"]),
     install_requires=[
-        "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@0b256cc#egg=aas-core-meta",
-        "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@a8a510e#egg=aas-core-codegen",
+        "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@44756fb#egg=aas-core-meta",
+        "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@e2b793f#egg=aas-core-codegen",
     ],
     py_modules=["test_codegen"],
 )

--- a/src/AasCore.Aas3_0/types.cs
+++ b/src/AasCore.Aas3_0/types.cs
@@ -776,18 +776,20 @@ namespace AasCore.Aas3_0
     /// </summary>
     /// <remarks>
     /// <para>
-    /// This constraint is checked at <see cref="Aas.Submodel" />.
-    /// </para>
-    /// <para>
     /// Constraints:
     /// </para>
     /// <ul>
     ///   <li>
+    ///     <para>
     ///     Constraint AASd-119:
     ///     If any <see cref="Aas.Qualifier.Kind" /> value of <see cref="Aas.IQualifiable.Qualifiers" /> is
     ///     equal to <see cref="Aas.QualifierKind.TemplateQualifier" /> and the qualified element
     ///     inherits from <see cref="Aas.IHasKind" /> then the qualified element shall be of
     ///     kind Template (<see cref="Aas.IHasKind.Kind" /> = <see cref="Aas.ModellingKind.Template" />).
+    ///     </para>
+    ///     <para>
+    ///     This constraint is checked at <see cref="Aas.Submodel" />.
+    ///     </para>
     ///   </li>
     /// </ul>
     /// </remarks>
@@ -1572,31 +1574,33 @@ namespace AasCore.Aas3_0
     /// optional.
     /// </para>
     /// <para>
-    /// Constraint AASd-116 is important to enable a generic search across global
-    /// and specific asset IDs.
-    /// </para>
-    /// <para>
-    /// <para>
-    /// In the book, Constraint AASd-116 imposes a
-    /// case-insensitive equality against <c>globalAssetId</c>. This is
-    /// culturally-dependent, and depends on the system settings.
-    /// For example, the case-folding for the letters "i" and "I" is
-    /// different in Turkish from English.
-    /// </para>
-    /// <para>
-    /// We implement the constraint as case-sensitive instead to allow
-    /// for interoperability across different culture settings.
-    /// </para>
-    /// </para>
-    /// <para>
     /// Constraints:
     /// </para>
     /// <ul>
     ///   <li>
+    ///     <para>
     ///     Constraint AASd-116:
     ///     <c>globalAssetId</c> is a reserved key. If used as value for
     ///     <see cref="Aas.SpecificAssetId.Name" /> then <see cref="Aas.SpecificAssetId.Value" /> shall be
     ///     identical to <see cref="Aas.AssetInformation.GlobalAssetId" />.
+    ///     </para>
+    ///     <para>
+    ///     Constraint AASd-116 is important to enable a generic search across
+    ///     global and specific asset IDs.
+    ///     </para>
+    ///     <para>
+    ///     <para>
+    ///     In the book, Constraint AASd-116 imposes a
+    ///     case-insensitive equality against <c>globalAssetId</c>. This is
+    ///     culturally-dependent, and depends on the system settings.
+    ///     For example, the case-folding for the letters "i" and "I" is
+    ///     different in Turkish from English.
+    ///     </para>
+    ///     <para>
+    ///     We implement the constraint as case-sensitive instead to allow
+    ///     for interoperability across different culture settings.
+    ///     </para>
+    ///     </para>
     ///   </li>
     ///   <li>
     ///     Constraint AASd-131:
@@ -1677,31 +1681,33 @@ namespace AasCore.Aas3_0
     /// optional.
     /// </para>
     /// <para>
-    /// Constraint AASd-116 is important to enable a generic search across global
-    /// and specific asset IDs.
-    /// </para>
-    /// <para>
-    /// <para>
-    /// In the book, Constraint AASd-116 imposes a
-    /// case-insensitive equality against <c>globalAssetId</c>. This is
-    /// culturally-dependent, and depends on the system settings.
-    /// For example, the case-folding for the letters "i" and "I" is
-    /// different in Turkish from English.
-    /// </para>
-    /// <para>
-    /// We implement the constraint as case-sensitive instead to allow
-    /// for interoperability across different culture settings.
-    /// </para>
-    /// </para>
-    /// <para>
     /// Constraints:
     /// </para>
     /// <ul>
     ///   <li>
+    ///     <para>
     ///     Constraint AASd-116:
     ///     <c>globalAssetId</c> is a reserved key. If used as value for
     ///     <see cref="Aas.SpecificAssetId.Name" /> then <see cref="Aas.SpecificAssetId.Value" /> shall be
     ///     identical to <see cref="Aas.AssetInformation.GlobalAssetId" />.
+    ///     </para>
+    ///     <para>
+    ///     Constraint AASd-116 is important to enable a generic search across
+    ///     global and specific asset IDs.
+    ///     </para>
+    ///     <para>
+    ///     <para>
+    ///     In the book, Constraint AASd-116 imposes a
+    ///     case-insensitive equality against <c>globalAssetId</c>. This is
+    ///     culturally-dependent, and depends on the system settings.
+    ///     For example, the case-folding for the letters "i" and "I" is
+    ///     different in Turkish from English.
+    ///     </para>
+    ///     <para>
+    ///     We implement the constraint as case-sensitive instead to allow
+    ///     for interoperability across different culture settings.
+    ///     </para>
+    ///     </para>
     ///   </li>
     ///   <li>
     ///     Constraint AASd-131:
@@ -10171,25 +10177,64 @@ namespace AasCore.Aas3_0
     /// data specification template).
     /// </para>
     /// <para>
-    /// Note: categories are deprecated since V3.0 of Part 1a of the document series
-    /// "Details of the Asset Administration Shell".
-    /// </para>
-    /// <para>
-    /// Note: categories are deprecated since V3.0 of Part 1a of the document series
-    /// "Details of the Asset Administration Shell".
-    /// </para>
-    /// <para>
-    /// Categories are deprecated since V3.0 of Part 1a of the document series
-    /// "Details of the Asset Administration Shell".
-    /// </para>
-    /// <para>
-    /// Categories are deprecated since V3.0 of Part 1a of the document series
-    /// "Details of the Asset Administration Shell".
-    /// </para>
-    /// <para>
     /// Constraints:
     /// </para>
     /// <ul>
+    ///   <li>
+    ///     <para>
+    ///     Constraint AASc-3a-004:
+    ///     For a <see cref="Aas.ConceptDescription" /> with <see cref="Aas.ConceptDescription.Category" /> <c>PROPERTY</c> or
+    ///     <c>VALUE</c> using data specification IEC61360,
+    ///     the <see cref="Aas.DataSpecificationIec61360.DataType" /> is mandatory and shall be
+    ///     one of: <c>DATE</c>, <c>STRING</c>, <c>STRING_TRANSLATABLE</c>, <c>INTEGER_MEASURE</c>,
+    ///     <c>INTEGER_COUNT</c>, <c>INTEGER_CURRENCY</c>, <c>REAL_MEASURE</c>, <c>REAL_COUNT</c>,
+    ///     <c>REAL_CURRENCY</c>, <c>BOOLEAN</c>, <c>RATIONAL</c>, <c>RATIONAL_MEASURE</c>,
+    ///     <c>TIME</c>, <c>TIMESTAMP</c>.
+    ///     </para>
+    ///     <para>
+    ///     Note: categories are deprecated since V3.0 of Part 1a of the document series
+    ///     "Details of the Asset Administration Shell".
+    ///     </para>
+    ///   </li>
+    ///   <li>
+    ///     <para>
+    ///     Constraint AASc-3a-005:
+    ///     For a <see cref="Aas.ConceptDescription" /> with <see cref="Aas.ConceptDescription.Category" /> <c>REFERENCE</c>
+    ///     using data specification template IEC61360,
+    ///     the <see cref="Aas.DataSpecificationIec61360.DataType" /> shall be
+    ///     one of: <c>STRING</c>, <c>IRI</c>, <c>IRDI</c>.
+    ///     </para>
+    ///     <para>
+    ///     Note: categories are deprecated since V3.0 of Part 1a of the document series
+    ///     "Details of the Asset Administration Shell".
+    ///     </para>
+    ///   </li>
+    ///   <li>
+    ///     <para>
+    ///     Constraint AASc-3a-006:
+    ///     For a <see cref="Aas.ConceptDescription" /> with <see cref="Aas.ConceptDescription.Category" /> <c>DOCUMENT</c>
+    ///     using data specification IEC61360,
+    ///     the <see cref="Aas.DataSpecificationIec61360.DataType" /> shall be one of <c>FILE</c>,
+    ///     <c>BLOB</c>, <c>HTML</c>
+    ///     </para>
+    ///     <para>
+    ///     Categories are deprecated since V3.0 of Part 1a of the document series
+    ///     "Details of the Asset Administration Shell".
+    ///     </para>
+    ///   </li>
+    ///   <li>
+    ///     <para>
+    ///     Constraint AASc-3a-007:
+    ///     For a <see cref="Aas.ConceptDescription" /> with <see cref="Aas.ConceptDescription.Category" /> <c>QUALIFIER_TYPE</c>
+    ///     using data specification IEC61360,
+    ///     the <see cref="Aas.DataSpecificationIec61360.DataType" /> is mandatory and shall be
+    ///     defined.
+    ///     </para>
+    ///     <para>
+    ///     Categories are deprecated since V3.0 of Part 1a of the document series
+    ///     "Details of the Asset Administration Shell".
+    ///     </para>
+    ///   </li>
     ///   <li>
     ///     <para>
     ///     Constraint AASc-3a-008:
@@ -10245,25 +10290,64 @@ namespace AasCore.Aas3_0
     /// data specification template).
     /// </para>
     /// <para>
-    /// Note: categories are deprecated since V3.0 of Part 1a of the document series
-    /// "Details of the Asset Administration Shell".
-    /// </para>
-    /// <para>
-    /// Note: categories are deprecated since V3.0 of Part 1a of the document series
-    /// "Details of the Asset Administration Shell".
-    /// </para>
-    /// <para>
-    /// Categories are deprecated since V3.0 of Part 1a of the document series
-    /// "Details of the Asset Administration Shell".
-    /// </para>
-    /// <para>
-    /// Categories are deprecated since V3.0 of Part 1a of the document series
-    /// "Details of the Asset Administration Shell".
-    /// </para>
-    /// <para>
     /// Constraints:
     /// </para>
     /// <ul>
+    ///   <li>
+    ///     <para>
+    ///     Constraint AASc-3a-004:
+    ///     For a <see cref="Aas.ConceptDescription" /> with <see cref="Aas.ConceptDescription.Category" /> <c>PROPERTY</c> or
+    ///     <c>VALUE</c> using data specification IEC61360,
+    ///     the <see cref="Aas.DataSpecificationIec61360.DataType" /> is mandatory and shall be
+    ///     one of: <c>DATE</c>, <c>STRING</c>, <c>STRING_TRANSLATABLE</c>, <c>INTEGER_MEASURE</c>,
+    ///     <c>INTEGER_COUNT</c>, <c>INTEGER_CURRENCY</c>, <c>REAL_MEASURE</c>, <c>REAL_COUNT</c>,
+    ///     <c>REAL_CURRENCY</c>, <c>BOOLEAN</c>, <c>RATIONAL</c>, <c>RATIONAL_MEASURE</c>,
+    ///     <c>TIME</c>, <c>TIMESTAMP</c>.
+    ///     </para>
+    ///     <para>
+    ///     Note: categories are deprecated since V3.0 of Part 1a of the document series
+    ///     "Details of the Asset Administration Shell".
+    ///     </para>
+    ///   </li>
+    ///   <li>
+    ///     <para>
+    ///     Constraint AASc-3a-005:
+    ///     For a <see cref="Aas.ConceptDescription" /> with <see cref="Aas.ConceptDescription.Category" /> <c>REFERENCE</c>
+    ///     using data specification template IEC61360,
+    ///     the <see cref="Aas.DataSpecificationIec61360.DataType" /> shall be
+    ///     one of: <c>STRING</c>, <c>IRI</c>, <c>IRDI</c>.
+    ///     </para>
+    ///     <para>
+    ///     Note: categories are deprecated since V3.0 of Part 1a of the document series
+    ///     "Details of the Asset Administration Shell".
+    ///     </para>
+    ///   </li>
+    ///   <li>
+    ///     <para>
+    ///     Constraint AASc-3a-006:
+    ///     For a <see cref="Aas.ConceptDescription" /> with <see cref="Aas.ConceptDescription.Category" /> <c>DOCUMENT</c>
+    ///     using data specification IEC61360,
+    ///     the <see cref="Aas.DataSpecificationIec61360.DataType" /> shall be one of <c>FILE</c>,
+    ///     <c>BLOB</c>, <c>HTML</c>
+    ///     </para>
+    ///     <para>
+    ///     Categories are deprecated since V3.0 of Part 1a of the document series
+    ///     "Details of the Asset Administration Shell".
+    ///     </para>
+    ///   </li>
+    ///   <li>
+    ///     <para>
+    ///     Constraint AASc-3a-007:
+    ///     For a <see cref="Aas.ConceptDescription" /> with <see cref="Aas.ConceptDescription.Category" /> <c>QUALIFIER_TYPE</c>
+    ///     using data specification IEC61360,
+    ///     the <see cref="Aas.DataSpecificationIec61360.DataType" /> is mandatory and shall be
+    ///     defined.
+    ///     </para>
+    ///     <para>
+    ///     Categories are deprecated since V3.0 of Part 1a of the document series
+    ///     "Details of the Asset Administration Shell".
+    ///     </para>
+    ///   </li>
     ///   <li>
     ///     <para>
     ///     Constraint AASc-3a-008:
@@ -12777,18 +12861,6 @@ namespace AasCore.Aas3_0
     /// </summary>
     /// <remarks>
     /// <para>
-    /// It is also possible that both <see cref="Aas.DataSpecificationIec61360.Value" /> and <see cref="Aas.DataSpecificationIec61360.ValueList" /> are empty.
-    /// This is the case for concept descriptions that define the semantics of a
-    /// property but do not have an enumeration (<see cref="Aas.DataSpecificationIec61360.ValueList" />) as data type.
-    /// </para>
-    /// <para>
-    /// Although it is possible to define a <see cref="Aas.ConceptDescription" /> for a
-    /// :attr:´value_list`,
-    /// it is not possible to reuse this <see cref="Aas.DataSpecificationIec61360.ValueList" />.
-    /// It is only possible to directly add a <see cref="Aas.DataSpecificationIec61360.ValueList" /> as data type
-    /// to a specific semantic definition of a property.
-    /// </para>
-    /// <para>
     /// IEC61360 requires also a globally unique identifier for a concept
     /// description. This ID is not part of the data specification template.
     /// Instead the <see cref="Aas.ConceptDescription.Id" /> as inherited via
@@ -12807,6 +12879,26 @@ namespace AasCore.Aas3_0
     /// Constraints:
     /// </para>
     /// <ul>
+    ///   <li>
+    ///     <para>
+    ///     Constraint AASc-3a-010:
+    ///     If <see cref="Aas.DataSpecificationIec61360.Value" /> is not empty then <see cref="Aas.DataSpecificationIec61360.ValueList" /> shall be empty
+    ///     and vice versa.
+    ///     </para>
+    ///     <para>
+    ///     It is also possible that both <see cref="Aas.DataSpecificationIec61360.Value" /> and <see cref="Aas.DataSpecificationIec61360.ValueList" /> are
+    ///     empty. This is the case for concept descriptions that define the semantics
+    ///     of a property but do not have an enumeration (<see cref="Aas.DataSpecificationIec61360.ValueList" />) as
+    ///     data type.
+    ///     </para>
+    ///     <para>
+    ///     Although it is possible to define a <see cref="Aas.ConceptDescription" /> for a
+    ///     :attr:´value_list`,
+    ///     it is not possible to reuse this <see cref="Aas.DataSpecificationIec61360.ValueList" />.
+    ///     It is only possible to directly add a <see cref="Aas.DataSpecificationIec61360.ValueList" /> as data type
+    ///     to a specific semantic definition of a property.
+    ///     </para>
+    ///   </li>
     ///   <li>
     ///     Constraint AASc-3a-009:
     ///     If <see cref="Aas.DataSpecificationIec61360.DataType" /> one of:
@@ -12924,18 +13016,6 @@ namespace AasCore.Aas3_0
     /// </summary>
     /// <remarks>
     /// <para>
-    /// It is also possible that both <see cref="Aas.DataSpecificationIec61360.Value" /> and <see cref="Aas.DataSpecificationIec61360.ValueList" /> are empty.
-    /// This is the case for concept descriptions that define the semantics of a
-    /// property but do not have an enumeration (<see cref="Aas.DataSpecificationIec61360.ValueList" />) as data type.
-    /// </para>
-    /// <para>
-    /// Although it is possible to define a <see cref="Aas.ConceptDescription" /> for a
-    /// :attr:´value_list`,
-    /// it is not possible to reuse this <see cref="Aas.DataSpecificationIec61360.ValueList" />.
-    /// It is only possible to directly add a <see cref="Aas.DataSpecificationIec61360.ValueList" /> as data type
-    /// to a specific semantic definition of a property.
-    /// </para>
-    /// <para>
     /// IEC61360 requires also a globally unique identifier for a concept
     /// description. This ID is not part of the data specification template.
     /// Instead the <see cref="Aas.ConceptDescription.Id" /> as inherited via
@@ -12954,6 +13034,26 @@ namespace AasCore.Aas3_0
     /// Constraints:
     /// </para>
     /// <ul>
+    ///   <li>
+    ///     <para>
+    ///     Constraint AASc-3a-010:
+    ///     If <see cref="Aas.DataSpecificationIec61360.Value" /> is not empty then <see cref="Aas.DataSpecificationIec61360.ValueList" /> shall be empty
+    ///     and vice versa.
+    ///     </para>
+    ///     <para>
+    ///     It is also possible that both <see cref="Aas.DataSpecificationIec61360.Value" /> and <see cref="Aas.DataSpecificationIec61360.ValueList" /> are
+    ///     empty. This is the case for concept descriptions that define the semantics
+    ///     of a property but do not have an enumeration (<see cref="Aas.DataSpecificationIec61360.ValueList" />) as
+    ///     data type.
+    ///     </para>
+    ///     <para>
+    ///     Although it is possible to define a <see cref="Aas.ConceptDescription" /> for a
+    ///     :attr:´value_list`,
+    ///     it is not possible to reuse this <see cref="Aas.DataSpecificationIec61360.ValueList" />.
+    ///     It is only possible to directly add a <see cref="Aas.DataSpecificationIec61360.ValueList" /> as data type
+    ///     to a specific semantic definition of a property.
+    ///     </para>
+    ///   </li>
     ///   <li>
     ///     Constraint AASc-3a-009:
     ///     If <see cref="Aas.DataSpecificationIec61360.DataType" /> one of:

--- a/src/AasCore.Aas3_0/verification.cs
+++ b/src/AasCore.Aas3_0/verification.cs
@@ -3248,7 +3248,8 @@ namespace AasCore.Aas3_0
                         that.SpecificAssetIds.All(
                             specificAssetId => specificAssetId.Name != "globalAssetId"
                                 || (
-                                    specificAssetId.Name == "globalAssetId"
+                                    (that.GlobalAssetId != null)
+                                    && specificAssetId.Name == "globalAssetId"
                                     && specificAssetId.Value == that.GlobalAssetId
                                 ))
                     )))
@@ -3617,7 +3618,7 @@ namespace AasCore.Aas3_0
                 if (!(
                     !(that.SubmodelElements != null)
                     || (
-                        !(that.Kind != ModellingKind.Template)
+                        !(that.KindOrDefault() != ModellingKind.Template)
                         || (
                             that.SubmodelElements.All(
                                 submodelElement => !(submodelElement.Qualifiers != null)
@@ -9314,7 +9315,7 @@ namespace AasCore.Aas3_0
 
                 if (!(
                     !(
-                        (that.DataType == null)
+                        (that.DataType != null)
                         && Aas.Constants.Iec61360DataTypesWithUnit.Contains(that.DataType)
                     )
                     || (

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AdministrativeInformation/creator.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AdministrativeInformation/creator.json
@@ -2,17 +2,7 @@
   "assetAdministrationShells": [
     {
       "administration": {
-        "creator": [
-          {
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "unexpected instance"
-              }
-            ],
-            "type": "ExternalReference"
-          }
-        ],
+        "creator": "Unexpected string value",
         "embeddedDataSpecifications": [
           {
             "dataSpecification": {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AdministrativeInformation/creator.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AdministrativeInformation/creator.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: assetAdministrationShells[0].administration.creator
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: assetAdministrationShells[0].administration.creator

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AnnotatedRelationshipElement/first.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AnnotatedRelationshipElement/first.json
@@ -56,17 +56,7 @@
               "name": "something_aa1af8b3"
             }
           ],
-          "first": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "first": "Unexpected string value",
           "idShort": "PiXO1wyHierj",
           "modelType": "AnnotatedRelationshipElement",
           "qualifiers": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AnnotatedRelationshipElement/first.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AnnotatedRelationshipElement/first.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: submodels[0].submodelElements[0].first
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: submodels[0].submodelElements[0].first

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AnnotatedRelationshipElement/second.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AnnotatedRelationshipElement/second.json
@@ -73,17 +73,7 @@
               "valueType": "xs:long"
             }
           ],
-          "second": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "second": "Unexpected string value",
           "semanticId": {
             "keys": [
               {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AnnotatedRelationshipElement/second.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AnnotatedRelationshipElement/second.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: submodels[0].submodelElements[0].second
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: submodels[0].submodelElements[0].second

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AnnotatedRelationshipElement/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AnnotatedRelationshipElement/semanticId.json
@@ -82,17 +82,7 @@
             ],
             "type": "ExternalReference"
           },
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AnnotatedRelationshipElement/semanticId.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AnnotatedRelationshipElement/semanticId.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: submodels[0].submodelElements[0].semanticId
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: submodels[0].submodelElements[0].semanticId

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetAdministrationShell/administration.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetAdministrationShell/administration.json
@@ -1,17 +1,7 @@
 {
   "assetAdministrationShells": [
     {
-      "administration": [
-        {
-          "keys": [
-            {
-              "type": "GlobalReference",
-              "value": "unexpected instance"
-            }
-          ],
-          "type": "ExternalReference"
-        }
-      ],
+      "administration": "Unexpected string value",
       "assetInformation": {
         "assetKind": "NotApplicable",
         "globalAssetId": "something_eea66fa1"

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetAdministrationShell/administration.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetAdministrationShell/administration.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: assetAdministrationShells[0].administration
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: assetAdministrationShells[0].administration

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetAdministrationShell/assetInformation.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetAdministrationShell/assetInformation.json
@@ -2,17 +2,7 @@
   "assetAdministrationShells": [
     {
       "administration": {},
-      "assetInformation": [
-        {
-          "keys": [
-            {
-              "type": "GlobalReference",
-              "value": "unexpected instance"
-            }
-          ],
-          "type": "ExternalReference"
-        }
-      ],
+      "assetInformation": "Unexpected string value",
       "category": "something_1dc62cea",
       "derivedFrom": {
         "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetAdministrationShell/assetInformation.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetAdministrationShell/assetInformation.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: assetAdministrationShells[0].assetInformation
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: assetAdministrationShells[0].assetInformation

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetAdministrationShell/derivedFrom.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetAdministrationShell/derivedFrom.json
@@ -7,17 +7,7 @@
         "globalAssetId": "something_eea66fa1"
       },
       "category": "something_1dc62cea",
-      "derivedFrom": [
-        {
-          "keys": [
-            {
-              "type": "GlobalReference",
-              "value": "unexpected instance"
-            }
-          ],
-          "type": "ExternalReference"
-        }
-      ],
+      "derivedFrom": "Unexpected string value",
       "description": [
         {
           "language": "Tvwqa-500-8EQd-y-8f5-k-vqdMn7-Ohw9-CcA628-DHKP-hPAjUZ-cnr1REUf-S8-p-9X0r-wtCI-KunG3uzI-7dGUsrTu-fY7-C3-hFN-Y-ML69DgnJ-0-Y0H-TLACBVB-Z0HRibbz-yzSf8dvR-zAn-B-6h8VjcKX-jnwR-0Z8l-ghRIZ7mo-wZG7-zXHdSIV-Oy-8dH00A6L-nJY2dA1-57o8dQ-RpxkBTbE-qBJR-M-DyGDA3U-aguRfIhj-x-XmO-1u",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetAdministrationShell/derivedFrom.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetAdministrationShell/derivedFrom.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: assetAdministrationShells[0].derivedFrom
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: assetAdministrationShells[0].derivedFrom

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetInformation/defaultThumbnail.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetInformation/defaultThumbnail.json
@@ -4,17 +4,7 @@
       "assetInformation": {
         "assetKind": "NotApplicable",
         "assetType": "something_9f4c5692",
-        "defaultThumbnail": [
-          {
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "unexpected instance"
-              }
-            ],
-            "type": "ExternalReference"
-          }
-        ],
+        "defaultThumbnail": "Unexpected string value",
         "globalAssetId": "something_c71f0c8f"
       },
       "id": "something_142922d6",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetInformation/defaultThumbnail.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetInformation/defaultThumbnail.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: assetAdministrationShells[0].assetInformation.defaultThumbnail
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: assetAdministrationShells[0].assetInformation.defaultThumbnail

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/messageBroker.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/messageBroker.json
@@ -54,17 +54,7 @@
           "idShort": "PiXO1wyHierj",
           "lastUpdate": "-3020-08-21T24:00:00.0Z",
           "maxInterval": "PT130S",
-          "messageBroker": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "messageBroker": "Unexpected string value",
           "messageTopic": "something_99f1a7ac",
           "minInterval": "-P1Y",
           "modelType": "BasicEventElement",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/messageBroker.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/messageBroker.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: submodels[0].submodelElements[0].messageBroker
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: submodels[0].submodelElements[0].messageBroker

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/observed.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/observed.json
@@ -66,17 +66,7 @@
           "messageTopic": "something_99f1a7ac",
           "minInterval": "-P1Y",
           "modelType": "BasicEventElement",
-          "observed": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "observed": "Unexpected string value",
           "qualifiers": [
             {
               "type": "something_500f973e",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/observed.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/observed.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: submodels[0].submodelElements[0].observed
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: submodels[0].submodelElements[0].observed

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/semanticId.json
@@ -81,17 +81,7 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "state": "off",
           "supplementalSemanticIds": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/semanticId.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/semanticId.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: submodels[0].submodelElements[0].semanticId
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: submodels[0].submodelElements[0].semanticId

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Blob/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Blob/semanticId.json
@@ -59,17 +59,7 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Blob/semanticId.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Blob/semanticId.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: submodels[0].submodelElements[0].semanticId
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: submodels[0].submodelElements[0].semanticId

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Capability/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Capability/semanticId.json
@@ -58,17 +58,7 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Capability/semanticId.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Capability/semanticId.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: submodels[0].submodelElements[0].semanticId
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: submodels[0].submodelElements[0].semanticId

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ConceptDescription/administration.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ConceptDescription/administration.json
@@ -1,17 +1,7 @@
 {
   "conceptDescriptions": [
     {
-      "administration": [
-        {
-          "keys": [
-            {
-              "type": "GlobalReference",
-              "value": "unexpected instance"
-            }
-          ],
-          "type": "ExternalReference"
-        }
-      ],
+      "administration": "Unexpected string value",
       "category": "something_07a45fb3",
       "description": [
         {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ConceptDescription/administration.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ConceptDescription/administration.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: conceptDescriptions[0].administration
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: conceptDescriptions[0].administration

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/DataSpecificationIec61360/levelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/DataSpecificationIec61360/levelType.json
@@ -24,17 +24,7 @@
                 "text": "something_2ae95f9f"
               }
             ],
-            "levelType": [
-              {
-                "keys": [
-                  {
-                    "type": "GlobalReference",
-                    "value": "unexpected instance"
-                  }
-                ],
-                "type": "ExternalReference"
-              }
-            ],
+            "levelType": "Unexpected string value",
             "modelType": "DataSpecificationIec61360",
             "preferredName": [
               {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/DataSpecificationIec61360/levelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/DataSpecificationIec61360/levelType.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.levelType
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.levelType

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/DataSpecificationIec61360/unitId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/DataSpecificationIec61360/unitId.json
@@ -50,17 +50,7 @@
             "sourceOfDefinition": "something_1bd907c8",
             "symbol": "something_c13116d7",
             "unit": "something_a6bd9450",
-            "unitId": [
-              {
-                "keys": [
-                  {
-                    "type": "GlobalReference",
-                    "value": "unexpected instance"
-                  }
-                ],
-                "type": "ExternalReference"
-              }
-            ],
+            "unitId": "Unexpected string value",
             "value": "something_13759f45",
             "valueFormat": "something_f019e5a8"
           }

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/DataSpecificationIec61360/unitId.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/DataSpecificationIec61360/unitId.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.unitId
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.unitId

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/EmbeddedDataSpecification/dataSpecification.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/EmbeddedDataSpecification/dataSpecification.json
@@ -7,17 +7,7 @@
       },
       "embeddedDataSpecifications": [
         {
-          "dataSpecification": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "dataSpecification": "Unexpected string value",
           "dataSpecificationContent": {
             "modelType": "DataSpecificationIec61360",
             "preferredName": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/EmbeddedDataSpecification/dataSpecification.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/EmbeddedDataSpecification/dataSpecification.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecification
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecification

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/EmbeddedDataSpecification/dataSpecificationContent.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/EmbeddedDataSpecification/dataSpecificationContent.json
@@ -16,17 +16,7 @@
             ],
             "type": "ExternalReference"
           },
-          "dataSpecificationContent": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ]
+          "dataSpecificationContent": "Unexpected string value"
         }
       ],
       "id": "something_142922d6",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Entity/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Entity/semanticId.json
@@ -59,17 +59,7 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "statements": [
             {
               "idShort": "something_7cdc9635",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Entity/semanticId.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Entity/semanticId.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: submodels[0].submodelElements[0].semanticId
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: submodels[0].submodelElements[0].semanticId

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Extension/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Extension/semanticId.json
@@ -19,17 +19,7 @@
               "type": "ModelReference"
             }
           ],
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Extension/semanticId.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Extension/semanticId.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: assetAdministrationShells[0].extensions[0].semanticId
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: assetAdministrationShells[0].extensions[0].semanticId

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/File/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/File/semanticId.json
@@ -59,17 +59,7 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/File/semanticId.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/File/semanticId.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: submodels[0].submodelElements[0].semanticId
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: submodels[0].submodelElements[0].semanticId

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/semanticId.json
@@ -58,17 +58,7 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/semanticId.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/semanticId.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: submodels[0].submodelElements[0].semanticId
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: submodels[0].submodelElements[0].semanticId

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/valueId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/valueId.json
@@ -84,17 +84,7 @@
               "text": "something_cd7e6587"
             }
           ],
-          "valueId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ]
+          "valueId": "Unexpected string value"
         }
       ]
     }

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/valueId.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/valueId.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: submodels[0].submodelElements[0].valueId
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: submodels[0].submodelElements[0].valueId

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Operation/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Operation/semanticId.json
@@ -102,17 +102,7 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Operation/semanticId.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Operation/semanticId.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: submodels[0].submodelElements[0].semanticId
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: submodels[0].submodelElements[0].semanticId

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/OperationVariable/value.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/OperationVariable/value.json
@@ -8,17 +8,7 @@
           "idShort": "something3fdd3eb4",
           "inputVariables": [
             {
-              "value": [
-                {
-                  "keys": [
-                    {
-                      "type": "GlobalReference",
-                      "value": "unexpected instance"
-                    }
-                  ],
-                  "type": "ExternalReference"
-                }
-              ]
+              "value": "Unexpected string value"
             }
           ],
           "modelType": "Operation"

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/semanticId.json
@@ -58,17 +58,7 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/semanticId.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/semanticId.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: submodels[0].submodelElements[0].semanticId
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: submodels[0].submodelElements[0].semanticId

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/valueId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/valueId.json
@@ -79,17 +79,7 @@
             }
           ],
           "value": "0061707",
-          "valueId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "valueId": "Unexpected string value",
           "valueType": "xs:decimal"
         }
       ]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/valueId.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/valueId.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: submodels[0].submodelElements[0].valueId
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: submodels[0].submodelElements[0].valueId

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Qualifier/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Qualifier/semanticId.json
@@ -7,17 +7,7 @@
       "qualifiers": [
         {
           "kind": "TemplateQualifier",
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Qualifier/semanticId.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Qualifier/semanticId.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: submodels[0].qualifiers[0].semanticId
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: submodels[0].qualifiers[0].semanticId

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Qualifier/valueId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Qualifier/valueId.json
@@ -29,17 +29,7 @@
           ],
           "type": "something_5964ab43",
           "value": "001",
-          "valueId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "valueId": "Unexpected string value",
           "valueType": "xs:integer"
         }
       ]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Qualifier/valueId.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Qualifier/valueId.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: submodels[0].qualifiers[0].valueId
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: submodels[0].qualifiers[0].valueId

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/semanticId.json
@@ -59,17 +59,7 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/semanticId.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/semanticId.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: submodels[0].submodelElements[0].semanticId
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: submodels[0].submodelElements[0].semanticId

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Reference/referredSemanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Reference/referredSemanticId.json
@@ -12,17 +12,7 @@
             "value": "urn:an-example08:f3f73640"
           }
         ],
-        "referredSemanticId": [
-          {
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "unexpected instance"
-              }
-            ],
-            "type": "ExternalReference"
-          }
-        ],
+        "referredSemanticId": "Unexpected string value",
         "type": "ModelReference"
       },
       "id": "something_142922d6",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Reference/referredSemanticId.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Reference/referredSemanticId.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: assetAdministrationShells[0].derivedFrom.referredSemanticId
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: assetAdministrationShells[0].derivedFrom.referredSemanticId

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/semanticId.json
@@ -58,17 +58,7 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/semanticId.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/semanticId.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: submodels[0].submodelElements[0].semanticId
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: submodels[0].submodelElements[0].semanticId

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/value.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/value.json
@@ -78,17 +78,7 @@
               "type": "ModelReference"
             }
           ],
-          "value": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ]
+          "value": "Unexpected string value"
         }
       ]
     }

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/value.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/value.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: submodels[0].submodelElements[0].value
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: submodels[0].submodelElements[0].value

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/RelationshipElement/first.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/RelationshipElement/first.json
@@ -50,17 +50,7 @@
               "name": "something_aa1af8b3"
             }
           ],
-          "first": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "first": "Unexpected string value",
           "idShort": "PiXO1wyHierj",
           "modelType": "RelationshipElement",
           "qualifiers": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/RelationshipElement/first.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/RelationshipElement/first.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: submodels[0].submodelElements[0].first
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: submodels[0].submodelElements[0].first

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/RelationshipElement/second.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/RelationshipElement/second.json
@@ -67,17 +67,7 @@
               "valueType": "xs:long"
             }
           ],
-          "second": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "second": "Unexpected string value",
           "semanticId": {
             "keys": [
               {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/RelationshipElement/second.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/RelationshipElement/second.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: submodels[0].submodelElements[0].second
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: submodels[0].submodelElements[0].second

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/RelationshipElement/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/RelationshipElement/semanticId.json
@@ -76,17 +76,7 @@
             ],
             "type": "ExternalReference"
           },
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/RelationshipElement/semanticId.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/RelationshipElement/semanticId.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: submodels[0].submodelElements[0].semanticId
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: submodels[0].submodelElements[0].semanticId

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SpecificAssetId/externalSubjectId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SpecificAssetId/externalSubjectId.json
@@ -5,17 +5,7 @@
         "assetKind": "NotApplicable",
         "specificAssetIds": [
           {
-            "externalSubjectId": [
-              {
-                "keys": [
-                  {
-                    "type": "GlobalReference",
-                    "value": "unexpected instance"
-                  }
-                ],
-                "type": "ExternalReference"
-              }
-            ],
+            "externalSubjectId": "Unexpected string value",
             "name": "something_b0b6ce88",
             "semanticId": {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SpecificAssetId/externalSubjectId.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SpecificAssetId/externalSubjectId.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: assetAdministrationShells[0].assetInformation.specificAssetIds[0].externalSubjectId
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: assetAdministrationShells[0].assetInformation.specificAssetIds[0].externalSubjectId

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SpecificAssetId/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SpecificAssetId/semanticId.json
@@ -15,17 +15,7 @@
               "type": "ExternalReference"
             },
             "name": "something_b0b6ce88",
-            "semanticId": [
-              {
-                "keys": [
-                  {
-                    "type": "GlobalReference",
-                    "value": "unexpected instance"
-                  }
-                ],
-                "type": "ExternalReference"
-              }
-            ],
+            "semanticId": "Unexpected string value",
             "supplementalSemanticIds": [
               {
                 "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SpecificAssetId/semanticId.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SpecificAssetId/semanticId.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: assetAdministrationShells[0].assetInformation.specificAssetIds[0].semanticId
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: assetAdministrationShells[0].assetInformation.specificAssetIds[0].semanticId

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Submodel/administration.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Submodel/administration.json
@@ -1,17 +1,7 @@
 {
   "submodels": [
     {
-      "administration": [
-        {
-          "keys": [
-            {
-              "type": "GlobalReference",
-              "value": "unexpected instance"
-            }
-          ],
-          "type": "ExternalReference"
-        }
-      ],
+      "administration": "Unexpected string value",
       "category": "something_91042c92",
       "description": [
         {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Submodel/administration.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Submodel/administration.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: submodels[0].administration
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: submodels[0].administration

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Submodel/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Submodel/semanticId.json
@@ -57,17 +57,7 @@
           "valueType": "xs:int"
         }
       ],
-      "semanticId": [
-        {
-          "keys": [
-            {
-              "type": "GlobalReference",
-              "value": "unexpected instance"
-            }
-          ],
-          "type": "ExternalReference"
-        }
-      ],
+      "semanticId": "Unexpected string value",
       "submodelElements": [
         {
           "first": {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Submodel/semanticId.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Submodel/semanticId.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: submodels[0].semanticId
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: submodels[0].semanticId

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementCollection/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementCollection/semanticId.json
@@ -58,17 +58,7 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementCollection/semanticId.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementCollection/semanticId.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: submodels[0].submodelElements[0].semanticId
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: submodels[0].submodelElements[0].semanticId

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/semanticId.json
@@ -59,17 +59,7 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "semanticIdListElement": {
             "keys": [
               {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/semanticId.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/semanticId.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: submodels[0].submodelElements[0].semanticId
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: submodels[0].submodelElements[0].semanticId

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/semanticIdListElement.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/semanticIdListElement.json
@@ -68,17 +68,7 @@
             ],
             "type": "ExternalReference"
           },
-          "semanticIdListElement": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticIdListElement": "Unexpected string value",
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/semanticIdListElement.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/semanticIdListElement.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: submodels[0].submodelElements[0].semanticIdListElement
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: submodels[0].submodelElements[0].semanticIdListElement

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ValueReferencePair/valueId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ValueReferencePair/valueId.json
@@ -32,17 +32,7 @@
               "valueReferencePairs": [
                 {
                   "value": "something_63781b6f",
-                  "valueId": [
-                    {
-                      "keys": [
-                        {
-                          "type": "GlobalReference",
-                          "value": "unexpected instance"
-                        }
-                      ],
-                      "type": "ExternalReference"
-                    }
-                  ]
+                  "valueId": "Unexpected string value"
                 }
               ]
             }

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ValueReferencePair/valueId.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ValueReferencePair/valueId.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.valueList.valueReferencePairs[0].valueId
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.valueList.valueReferencePairs[0].valueId

--- a/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/observableReference.json
+++ b/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/observableReference.json
@@ -1,15 +1,5 @@
 {
-  "observableReference": [
-    {
-      "keys": [
-        {
-          "type": "GlobalReference",
-          "value": "unexpected instance"
-        }
-      ],
-      "type": "ExternalReference"
-    }
-  ],
+  "observableReference": "Unexpected string value",
   "observableSemanticId": {
     "keys": [
       {

--- a/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/observableReference.json.exception
+++ b/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/observableReference.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: observableReference
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: observableReference

--- a/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/observableSemanticId.json
+++ b/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/observableSemanticId.json
@@ -8,17 +8,7 @@
     ],
     "type": "ModelReference"
   },
-  "observableSemanticId": [
-    {
-      "keys": [
-        {
-          "type": "GlobalReference",
-          "value": "unexpected instance"
-        }
-      ],
-      "type": "ExternalReference"
-    }
-  ],
+  "observableSemanticId": "Unexpected string value",
   "payload": "/TsF2AbyQb1dIa0=",
   "source": {
     "keys": [

--- a/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/observableSemanticId.json.exception
+++ b/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/observableSemanticId.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: observableSemanticId
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: observableSemanticId

--- a/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/source.json
+++ b/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/source.json
@@ -18,17 +18,7 @@
     "type": "ModelReference"
   },
   "payload": "/TsF2AbyQb1dIa0=",
-  "source": [
-    {
-      "keys": [
-        {
-          "type": "GlobalReference",
-          "value": "unexpected instance"
-        }
-      ],
-      "type": "ExternalReference"
-    }
-  ],
+  "source": "Unexpected string value",
   "sourceSemanticId": {
     "keys": [
       {

--- a/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/source.json.exception
+++ b/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/source.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: source
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: source

--- a/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/sourceSemanticId.json
+++ b/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/sourceSemanticId.json
@@ -31,17 +31,7 @@
     ],
     "type": "ModelReference"
   },
-  "sourceSemanticId": [
-    {
-      "keys": [
-        {
-          "type": "GlobalReference",
-          "value": "unexpected instance"
-        }
-      ],
-      "type": "ExternalReference"
-    }
-  ],
+  "sourceSemanticId": "Unexpected string value",
   "subjectId": {
     "keys": [
       {

--- a/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/sourceSemanticId.json.exception
+++ b/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/sourceSemanticId.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: sourceSemanticId
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: sourceSemanticId

--- a/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/subjectId.json
+++ b/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/subjectId.json
@@ -40,17 +40,7 @@
     ],
     "type": "ModelReference"
   },
-  "subjectId": [
-    {
-      "keys": [
-        {
-          "type": "GlobalReference",
-          "value": "unexpected instance"
-        }
-      ],
-      "type": "ExternalReference"
-    }
-  ],
+  "subjectId": "Unexpected string value",
   "timeStamp": "2022-04-01T24:00:00-00:00",
   "topic": "something_8f13d2dd"
 }

--- a/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/subjectId.json.exception
+++ b/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/subjectId.json.exception
@@ -1,1 +1,1 @@
-Expected a JsonObject, but got System.Text.Json.Nodes.JsonArray at: subjectId
+Expected a JsonObject, but got System.Text.Json.Nodes.JsonValueTrimmable`1[System.Text.Json.JsonElement] at: subjectId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/administrativeInformation/creator.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/administrativeInformation/creator.xml
@@ -32,17 +32,7 @@
 				</embeddedDataSpecifications>
 				<version>1230</version>
 				<revision>0</revision>
-				<creator>
-					<reference>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>unexpected instance</value>
-							</key>
-						</keys>
-					</reference>
-				</creator>
+				<creator>Unexpected string value</creator>
 				<templateId>something_cb08d136</templateId>
 			</administration>
 			<id>something_142922d6</id>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/administrativeInformation/creator.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/administrativeInformation/creator.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Reference, but got an unexpected element with the name reference at: assetAdministrationShells/*[0]/administration/creator
+The required property Type has not been given in the XML representation of an instance of class Reference at: assetAdministrationShells/*[0]/administration/creator

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/first.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/first.xml
@@ -77,17 +77,7 @@
 							</dataSpecificationContent>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
-					<first>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</first>
+					<first>Unexpected string value</first>
 					<second>
 						<type>ExternalReference</type>
 						<keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/first.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/first.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Reference, but got an unexpected element with the name reference at: submodels/*[0]/submodelElements/*[0]/first
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/first

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/second.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/second.xml
@@ -86,17 +86,7 @@
 							</key>
 						</keys>
 					</first>
-					<second>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</second>
+					<second>Unexpected string value</second>
 					<annotations>
 						<multiLanguageProperty>
 							<idShort>something_41aa6b27</idShort>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/second.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/second.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Reference, but got an unexpected element with the name reference at: submodels/*[0]/submodelElements/*[0]/second
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/second

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/semanticId.xml
@@ -23,17 +23,7 @@
 							<text>something_be9deae0</text>
 						</langStringTextType>
 					</description>
-					<semanticId>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</semanticId>
+					<semanticId>Unexpected string value</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/semanticId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/semanticId.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Reference, but got an unexpected element with the name reference at: submodels/*[0]/submodelElements/*[0]/semanticId
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/semanticId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/administration.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/administration.xml
@@ -20,17 +20,7 @@
 					<text>something_0c9e872c</text>
 				</langStringTextType>
 			</description>
-			<administration>
-				<reference>
-					<type>ExternalReference</type>
-					<keys>
-						<key>
-							<type>GlobalReference</type>
-							<value>unexpected instance</value>
-						</key>
-					</keys>
-				</reference>
-			</administration>
+			<administration>Unexpected string value</administration>
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/administration.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/administration.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class AdministrativeInformation, but got an unexpected element with the name reference at: assetAdministrationShells/*[0]/administration
+Expected an XML end element to conclude a property of class AssetAdministrationShell with the element name administration, but got the node of type Text with the value Unexpected string value at: assetAdministrationShells/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/assetInformation.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/assetInformation.xml
@@ -59,17 +59,7 @@
 					</key>
 				</keys>
 			</derivedFrom>
-			<assetInformation>
-				<reference>
-					<type>ExternalReference</type>
-					<keys>
-						<key>
-							<type>GlobalReference</type>
-							<value>unexpected instance</value>
-						</key>
-					</keys>
-				</reference>
-			</assetInformation>
+			<assetInformation>Unexpected string value</assetInformation>
 			<submodels>
 				<reference>
 					<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/assetInformation.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/assetInformation.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class AssetInformation, but got an unexpected element with the name reference at: assetAdministrationShells/*[0]/assetInformation
+The required property AssetKind has not been given in the XML representation of an instance of class AssetInformation at: assetAdministrationShells/*[0]/assetInformation

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/derivedFrom.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/derivedFrom.xml
@@ -50,17 +50,7 @@
 					</dataSpecificationContent>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
-			<derivedFrom>
-				<reference>
-					<type>ExternalReference</type>
-					<keys>
-						<key>
-							<type>GlobalReference</type>
-							<value>unexpected instance</value>
-						</key>
-					</keys>
-				</reference>
-			</derivedFrom>
+			<derivedFrom>Unexpected string value</derivedFrom>
 			<assetInformation>
 				<assetKind>NotApplicable</assetKind>
 				<globalAssetId>something_eea66fa1</globalAssetId>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/derivedFrom.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/derivedFrom.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Reference, but got an unexpected element with the name reference at: assetAdministrationShells/*[0]/derivedFrom
+The required property Type has not been given in the XML representation of an instance of class Reference at: assetAdministrationShells/*[0]/derivedFrom

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetInformation/defaultThumbnail.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetInformation/defaultThumbnail.xml
@@ -6,17 +6,7 @@
 				<assetKind>NotApplicable</assetKind>
 				<globalAssetId>something_c71f0c8f</globalAssetId>
 				<assetType>something_9f4c5692</assetType>
-				<defaultThumbnail>
-					<reference>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>unexpected instance</value>
-							</key>
-						</keys>
-					</reference>
-				</defaultThumbnail>
+				<defaultThumbnail>Unexpected string value</defaultThumbnail>
 			</assetInformation>
 		</assetAdministrationShell>
 	</assetAdministrationShells>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetInformation/defaultThumbnail.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetInformation/defaultThumbnail.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Resource, but got an unexpected element with the name reference at: assetAdministrationShells/*[0]/assetInformation/defaultThumbnail
+The required property Path has not been given in the XML representation of an instance of class Resource at: assetAdministrationShells/*[0]/assetInformation/defaultThumbnail

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/messageBroker.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/messageBroker.xml
@@ -89,17 +89,7 @@
 					<direction>output</direction>
 					<state>off</state>
 					<messageTopic>something_99f1a7ac</messageTopic>
-					<messageBroker>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</messageBroker>
+					<messageBroker>Unexpected string value</messageBroker>
 					<lastUpdate>-3020-08-21T24:00:00.0Z</lastUpdate>
 					<minInterval>-P1Y</minInterval>
 					<maxInterval>PT130S</maxInterval>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/messageBroker.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/messageBroker.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Reference, but got an unexpected element with the name reference at: submodels/*[0]/submodelElements/*[0]/messageBroker
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/messageBroker

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/observed.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/observed.xml
@@ -77,17 +77,7 @@
 							</dataSpecificationContent>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
-					<observed>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</observed>
+					<observed>Unexpected string value</observed>
 					<direction>output</direction>
 					<state>off</state>
 					<messageTopic>something_99f1a7ac</messageTopic>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/observed.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/observed.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Reference, but got an unexpected element with the name reference at: submodels/*[0]/submodelElements/*[0]/observed
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/observed

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/semanticId.xml
@@ -23,17 +23,7 @@
 							<text>something_be9deae0</text>
 						</langStringTextType>
 					</description>
-					<semanticId>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</semanticId>
+					<semanticId>Unexpected string value</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/semanticId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/semanticId.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Reference, but got an unexpected element with the name reference at: submodels/*[0]/submodelElements/*[0]/semanticId
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/semanticId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/semanticId.xml
@@ -23,17 +23,7 @@
 							<text>something_be9deae0</text>
 						</langStringTextType>
 					</description>
-					<semanticId>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</semanticId>
+					<semanticId>Unexpected string value</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/semanticId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/semanticId.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Reference, but got an unexpected element with the name reference at: submodels/*[0]/submodelElements/*[0]/semanticId
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/semanticId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/capability/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/capability/semanticId.xml
@@ -23,17 +23,7 @@
 							<text>something_be9deae0</text>
 						</langStringTextType>
 					</description>
-					<semanticId>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</semanticId>
+					<semanticId>Unexpected string value</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/capability/semanticId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/capability/semanticId.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Reference, but got an unexpected element with the name reference at: submodels/*[0]/submodelElements/*[0]/semanticId
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/semanticId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/administration.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/administration.xml
@@ -20,17 +20,7 @@
 					<text>something_863a162e</text>
 				</langStringTextType>
 			</description>
-			<administration>
-				<reference>
-					<type>ExternalReference</type>
-					<keys>
-						<key>
-							<type>GlobalReference</type>
-							<value>unexpected instance</value>
-						</key>
-					</keys>
-				</reference>
-			</administration>
+			<administration>Unexpected string value</administration>
 			<id>something_8ccad77f</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/administration.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/administration.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class AdministrativeInformation, but got an unexpected element with the name reference at: conceptDescriptions/*[0]/administration
+Expected an XML end element to conclude a property of class ConceptDescription with the element name administration, but got the node of type Text with the value Unexpected string value at: conceptDescriptions/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/levelType.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/levelType.xml
@@ -52,17 +52,7 @@
 							</definition>
 							<valueFormat>something_f019e5a8</valueFormat>
 							<value>something_13759f45</value>
-							<levelType>
-								<reference>
-									<type>ExternalReference</type>
-									<keys>
-										<key>
-											<type>GlobalReference</type>
-											<value>unexpected instance</value>
-										</key>
-									</keys>
-								</reference>
-							</levelType>
+							<levelType>Unexpected string value</levelType>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
 				</embeddedDataSpecification>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/levelType.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/levelType.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class LevelType, but got an unexpected element with the name reference at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationIec61360/levelType
+The required property Min has not been given in the XML representation of an instance of class LevelType at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationIec61360/levelType

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/unitId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/unitId.xml
@@ -32,17 +32,7 @@
 								</langStringShortNameTypeIec61360>
 							</shortName>
 							<unit>something_a6bd9450</unit>
-							<unitId>
-								<reference>
-									<type>ExternalReference</type>
-									<keys>
-										<key>
-											<type>GlobalReference</type>
-											<value>unexpected instance</value>
-										</key>
-									</keys>
-								</reference>
-							</unitId>
+							<unitId>Unexpected string value</unitId>
 							<sourceOfDefinition>something_1bd907c8</sourceOfDefinition>
 							<symbol>something_c13116d7</symbol>
 							<dataType>DATE</dataType>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/unitId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/unitId.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Reference, but got an unexpected element with the name reference at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationIec61360/unitId
+The required property Type has not been given in the XML representation of an instance of class Reference at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationIec61360/unitId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/embeddedDataSpecification/dataSpecification.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/embeddedDataSpecification/dataSpecification.xml
@@ -4,17 +4,7 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
-					<dataSpecification>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</dataSpecification>
+					<dataSpecification>Unexpected string value</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/embeddedDataSpecification/dataSpecification.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/embeddedDataSpecification/dataSpecification.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Reference, but got an unexpected element with the name reference at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecification
+The required property Type has not been given in the XML representation of an instance of class Reference at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecification

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/embeddedDataSpecification/dataSpecificationContent.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/embeddedDataSpecification/dataSpecificationContent.xml
@@ -13,17 +13,7 @@
 							</key>
 						</keys>
 					</dataSpecification>
-					<dataSpecificationContent>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</dataSpecificationContent>
+					<dataSpecificationContent>Unexpected string value</dataSpecificationContent>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/embeddedDataSpecification/dataSpecificationContent.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/embeddedDataSpecification/dataSpecificationContent.xml.exception
@@ -1,1 +1,1 @@
-Unexpected element with the name reference at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/reference
+Expected an XML element, but got a node of type Text with value Unexpected string value at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/semanticId.xml
@@ -23,17 +23,7 @@
 							<text>something_be9deae0</text>
 						</langStringTextType>
 					</description>
-					<semanticId>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</semanticId>
+					<semanticId>Unexpected string value</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/semanticId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/semanticId.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Reference, but got an unexpected element with the name reference at: submodels/*[0]/submodelElements/*[0]/semanticId
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/semanticId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/extension/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/extension/semanticId.xml
@@ -3,17 +3,7 @@
 		<assetAdministrationShell>
 			<extensions>
 				<extension>
-					<semanticId>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</semanticId>
+					<semanticId>Unexpected string value</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ExternalReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/extension/semanticId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/extension/semanticId.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Reference, but got an unexpected element with the name reference at: assetAdministrationShells/*[0]/extensions/*[0]/semanticId
+The required property Type has not been given in the XML representation of an instance of class Reference at: assetAdministrationShells/*[0]/extensions/*[0]/semanticId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/semanticId.xml
@@ -23,17 +23,7 @@
 							<text>something_be9deae0</text>
 						</langStringTextType>
 					</description>
-					<semanticId>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</semanticId>
+					<semanticId>Unexpected string value</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/semanticId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/semanticId.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Reference, but got an unexpected element with the name reference at: submodels/*[0]/submodelElements/*[0]/semanticId
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/semanticId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/semanticId.xml
@@ -23,17 +23,7 @@
 							<text>something_be9deae0</text>
 						</langStringTextType>
 					</description>
-					<semanticId>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</semanticId>
+					<semanticId>Unexpected string value</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/semanticId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/semanticId.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Reference, but got an unexpected element with the name reference at: submodels/*[0]/submodelElements/*[0]/semanticId
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/semanticId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/valueId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/valueId.xml
@@ -83,17 +83,7 @@
 							<text>something_cd7e6587</text>
 						</langStringTextType>
 					</value>
-					<valueId>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</valueId>
+					<valueId>Unexpected string value</valueId>
 				</multiLanguageProperty>
 			</submodelElements>
 		</submodel>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/valueId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/valueId.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Reference, but got an unexpected element with the name reference at: submodels/*[0]/submodelElements/*[0]/valueId
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/valueId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operation/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operation/semanticId.xml
@@ -23,17 +23,7 @@
 							<text>something_be9deae0</text>
 						</langStringTextType>
 					</description>
-					<semanticId>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</semanticId>
+					<semanticId>Unexpected string value</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operation/semanticId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operation/semanticId.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Reference, but got an unexpected element with the name reference at: submodels/*[0]/submodelElements/*[0]/semanticId
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/semanticId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operationVariable/value.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operationVariable/value.xml
@@ -7,17 +7,7 @@
 					<idShort>something3fdd3eb4</idShort>
 					<inputVariables>
 						<operationVariable>
-							<value>
-								<reference>
-									<type>ExternalReference</type>
-									<keys>
-										<key>
-											<type>GlobalReference</type>
-											<value>unexpected instance</value>
-										</key>
-									</keys>
-								</reference>
-							</value>
+							<value>Unexpected string value</value>
 						</operationVariable>
 					</inputVariables>
 				</operation>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operationVariable/value.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operationVariable/value.xml.exception
@@ -1,1 +1,1 @@
-Unexpected element with the name reference at: submodels/*[0]/submodelElements/*[0]/inputVariables/*[0]/value/reference
+Expected an XML element, but got a node of type Text with value Unexpected string value at: submodels/*[0]/submodelElements/*[0]/inputVariables/*[0]/value

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/semanticId.xml
@@ -23,17 +23,7 @@
 							<text>something_be9deae0</text>
 						</langStringTextType>
 					</description>
-					<semanticId>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</semanticId>
+					<semanticId>Unexpected string value</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/semanticId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/semanticId.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Reference, but got an unexpected element with the name reference at: submodels/*[0]/submodelElements/*[0]/semanticId
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/semanticId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/valueId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/valueId.xml
@@ -79,17 +79,7 @@
 					</embeddedDataSpecifications>
 					<valueType>xs:decimal</valueType>
 					<value>0061707</value>
-					<valueId>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</valueId>
+					<valueId>Unexpected string value</valueId>
 				</property>
 			</submodelElements>
 		</submodel>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/valueId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/valueId.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Reference, but got an unexpected element with the name reference at: submodels/*[0]/submodelElements/*[0]/valueId
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/valueId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/semanticId.xml
@@ -5,17 +5,7 @@
 			<kind>Template</kind>
 			<qualifiers>
 				<qualifier>
-					<semanticId>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</semanticId>
+					<semanticId>Unexpected string value</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ExternalReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/semanticId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/semanticId.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Reference, but got an unexpected element with the name reference at: submodels/*[0]/qualifiers/*[0]/semanticId
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/qualifiers/*[0]/semanticId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/valueId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/valueId.xml
@@ -29,17 +29,7 @@
 					<type>something_5964ab43</type>
 					<valueType>xs:integer</valueType>
 					<value>001</value>
-					<valueId>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</valueId>
+					<valueId>Unexpected string value</valueId>
 				</qualifier>
 			</qualifiers>
 		</submodel>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/valueId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/valueId.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Reference, but got an unexpected element with the name reference at: submodels/*[0]/qualifiers/*[0]/valueId
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/qualifiers/*[0]/valueId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/semanticId.xml
@@ -23,17 +23,7 @@
 							<text>something_be9deae0</text>
 						</langStringTextType>
 					</description>
-					<semanticId>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</semanticId>
+					<semanticId>Unexpected string value</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/semanticId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/semanticId.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Reference, but got an unexpected element with the name reference at: submodels/*[0]/submodelElements/*[0]/semanticId
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/semanticId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/reference/referredSemanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/reference/referredSemanticId.xml
@@ -4,17 +4,7 @@
 			<id>something_142922d6</id>
 			<derivedFrom>
 				<type>ModelReference</type>
-				<referredSemanticId>
-					<reference>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>unexpected instance</value>
-							</key>
-						</keys>
-					</reference>
-				</referredSemanticId>
+				<referredSemanticId>Unexpected string value</referredSemanticId>
 				<keys>
 					<key>
 						<type>AssetAdministrationShell</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/reference/referredSemanticId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/reference/referredSemanticId.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Reference, but got an unexpected element with the name reference at: assetAdministrationShells/*[0]/derivedFrom/referredSemanticId
+The required property Type has not been given in the XML representation of an instance of class Reference at: assetAdministrationShells/*[0]/derivedFrom/referredSemanticId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/semanticId.xml
@@ -23,17 +23,7 @@
 							<text>something_be9deae0</text>
 						</langStringTextType>
 					</description>
-					<semanticId>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</semanticId>
+					<semanticId>Unexpected string value</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/semanticId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/semanticId.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Reference, but got an unexpected element with the name reference at: submodels/*[0]/submodelElements/*[0]/semanticId
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/semanticId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/value.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/value.xml
@@ -77,17 +77,7 @@
 							</dataSpecificationContent>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
-					<value>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</value>
+					<value>Unexpected string value</value>
 				</referenceElement>
 			</submodelElements>
 		</submodel>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/value.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/value.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Reference, but got an unexpected element with the name reference at: submodels/*[0]/submodelElements/*[0]/value
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/value

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/first.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/first.xml
@@ -77,17 +77,7 @@
 							</dataSpecificationContent>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
-					<first>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</first>
+					<first>Unexpected string value</first>
 					<second>
 						<type>ExternalReference</type>
 						<keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/first.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/first.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Reference, but got an unexpected element with the name reference at: submodels/*[0]/submodelElements/*[0]/first
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/first

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/second.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/second.xml
@@ -86,17 +86,7 @@
 							</key>
 						</keys>
 					</first>
-					<second>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</second>
+					<second>Unexpected string value</second>
 				</relationshipElement>
 			</submodelElements>
 		</submodel>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/second.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/second.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Reference, but got an unexpected element with the name reference at: submodels/*[0]/submodelElements/*[0]/second
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/second

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/semanticId.xml
@@ -23,17 +23,7 @@
 							<text>something_be9deae0</text>
 						</langStringTextType>
 					</description>
-					<semanticId>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</semanticId>
+					<semanticId>Unexpected string value</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/semanticId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/semanticId.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Reference, but got an unexpected element with the name reference at: submodels/*[0]/submodelElements/*[0]/semanticId
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/semanticId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/specificAssetId/externalSubjectId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/specificAssetId/externalSubjectId.xml
@@ -28,17 +28,7 @@
 						</supplementalSemanticIds>
 						<name>something_b0b6ce88</name>
 						<value>something_a37abe43</value>
-						<externalSubjectId>
-							<reference>
-								<type>ExternalReference</type>
-								<keys>
-									<key>
-										<type>GlobalReference</type>
-										<value>unexpected instance</value>
-									</key>
-								</keys>
-							</reference>
-						</externalSubjectId>
+						<externalSubjectId>Unexpected string value</externalSubjectId>
 					</specificAssetId>
 				</specificAssetIds>
 			</assetInformation>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/specificAssetId/externalSubjectId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/specificAssetId/externalSubjectId.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Reference, but got an unexpected element with the name reference at: assetAdministrationShells/*[0]/assetInformation/specificAssetIds/*[0]/externalSubjectId
+The required property Type has not been given in the XML representation of an instance of class Reference at: assetAdministrationShells/*[0]/assetInformation/specificAssetIds/*[0]/externalSubjectId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/specificAssetId/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/specificAssetId/semanticId.xml
@@ -6,17 +6,7 @@
 				<assetKind>NotApplicable</assetKind>
 				<specificAssetIds>
 					<specificAssetId>
-						<semanticId>
-							<reference>
-								<type>ExternalReference</type>
-								<keys>
-									<key>
-										<type>GlobalReference</type>
-										<value>unexpected instance</value>
-									</key>
-								</keys>
-							</reference>
-						</semanticId>
+						<semanticId>Unexpected string value</semanticId>
 						<supplementalSemanticIds>
 							<reference>
 								<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/specificAssetId/semanticId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/specificAssetId/semanticId.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Reference, but got an unexpected element with the name reference at: assetAdministrationShells/*[0]/assetInformation/specificAssetIds/*[0]/semanticId
+The required property Type has not been given in the XML representation of an instance of class Reference at: assetAdministrationShells/*[0]/assetInformation/specificAssetIds/*[0]/semanticId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/administration.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/administration.xml
@@ -20,17 +20,7 @@
 					<text>something_9a9e9635</text>
 				</langStringTextType>
 			</description>
-			<administration>
-				<reference>
-					<type>ExternalReference</type>
-					<keys>
-						<key>
-							<type>GlobalReference</type>
-							<value>unexpected instance</value>
-						</key>
-					</keys>
-				</reference>
-			</administration>
+			<administration>Unexpected string value</administration>
 			<id>something_48c66017</id>
 			<kind>Instance</kind>
 			<semanticId>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/administration.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/administration.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class AdministrativeInformation, but got an unexpected element with the name reference at: submodels/*[0]/administration
+Expected an XML end element to conclude a property of class Submodel with the element name administration, but got the node of type Text with the value Unexpected string value at: submodels/*[0]

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/semanticId.xml
@@ -23,17 +23,7 @@
 			<administration/>
 			<id>something_48c66017</id>
 			<kind>Instance</kind>
-			<semanticId>
-				<reference>
-					<type>ExternalReference</type>
-					<keys>
-						<key>
-							<type>GlobalReference</type>
-							<value>unexpected instance</value>
-						</key>
-					</keys>
-				</reference>
-			</semanticId>
+			<semanticId>Unexpected string value</semanticId>
 			<supplementalSemanticIds>
 				<reference>
 					<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/semanticId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/semanticId.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Reference, but got an unexpected element with the name reference at: submodels/*[0]/semanticId
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/semanticId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementCollection/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementCollection/semanticId.xml
@@ -23,17 +23,7 @@
 							<text>something_be9deae0</text>
 						</langStringTextType>
 					</description>
-					<semanticId>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</semanticId>
+					<semanticId>Unexpected string value</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementCollection/semanticId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementCollection/semanticId.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Reference, but got an unexpected element with the name reference at: submodels/*[0]/submodelElements/*[0]/semanticId
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/semanticId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/semanticId.xml
@@ -23,17 +23,7 @@
 							<text>something_be9deae0</text>
 						</langStringTextType>
 					</description>
-					<semanticId>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</semanticId>
+					<semanticId>Unexpected string value</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/semanticId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/semanticId.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Reference, but got an unexpected element with the name reference at: submodels/*[0]/submodelElements/*[0]/semanticId
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/semanticId

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/semanticIdListElement.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/semanticIdListElement.xml
@@ -78,17 +78,7 @@
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<orderRelevant>true</orderRelevant>
-					<semanticIdListElement>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</semanticIdListElement>
+					<semanticIdListElement>Unexpected string value</semanticIdListElement>
 					<typeValueListElement>Entity</typeValueListElement>
 					<valueTypeListElement>xs:byte</valueTypeListElement>
 					<value>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/semanticIdListElement.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/semanticIdListElement.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Reference, but got an unexpected element with the name reference at: submodels/*[0]/submodelElements/*[0]/semanticIdListElement
+The required property Type has not been given in the XML representation of an instance of class Reference at: submodels/*[0]/submodelElements/*[0]/semanticIdListElement

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/valueReferencePair/valueId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/valueReferencePair/valueId.xml
@@ -29,17 +29,7 @@
 								<valueReferencePairs>
 									<valueReferencePair>
 										<value>something_63781b6f</value>
-										<valueId>
-											<reference>
-												<type>ExternalReference</type>
-												<keys>
-													<key>
-														<type>GlobalReference</type>
-														<value>unexpected instance</value>
-													</key>
-												</keys>
-											</reference>
-										</valueId>
+										<valueId>Unexpected string value</valueId>
 									</valueReferencePair>
 								</valueReferencePairs>
 							</valueList>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/valueReferencePair/valueId.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/valueReferencePair/valueId.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Reference, but got an unexpected element with the name reference at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationIec61360/valueList/valueReferencePairs/*[0]/valueId
+The required property Type has not been given in the XML representation of an instance of class Reference at: assetAdministrationShells/*[0]/embeddedDataSpecifications/*[0]/dataSpecificationContent/dataSpecificationIec61360/valueList/valueReferencePairs/*[0]/valueId

--- a/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/observableReference.xml
+++ b/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/observableReference.xml
@@ -21,17 +21,7 @@
 			</key>
 		</keys>
 	</sourceSemanticId>
-	<observableReference>
-		<reference>
-			<type>ExternalReference</type>
-			<keys>
-				<key>
-					<type>GlobalReference</type>
-					<value>unexpected instance</value>
-				</key>
-			</keys>
-		</reference>
-	</observableReference>
+	<observableReference>Unexpected string value</observableReference>
 	<observableSemanticId>
 		<type>ModelReference</type>
 		<keys>

--- a/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/observableReference.xml.exception
+++ b/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/observableReference.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Reference, but got an unexpected element with the name reference at: observableReference
+The required property Type has not been given in the XML representation of an instance of class Reference at: observableReference

--- a/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/observableSemanticId.xml
+++ b/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/observableSemanticId.xml
@@ -30,17 +30,7 @@
 			</key>
 		</keys>
 	</observableReference>
-	<observableSemanticId>
-		<reference>
-			<type>ExternalReference</type>
-			<keys>
-				<key>
-					<type>GlobalReference</type>
-					<value>unexpected instance</value>
-				</key>
-			</keys>
-		</reference>
-	</observableSemanticId>
+	<observableSemanticId>Unexpected string value</observableSemanticId>
 	<topic>something_8f13d2dd</topic>
 	<subjectId>
 		<type>ExternalReference</type>

--- a/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/observableSemanticId.xml.exception
+++ b/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/observableSemanticId.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Reference, but got an unexpected element with the name reference at: observableSemanticId
+The required property Type has not been given in the XML representation of an instance of class Reference at: observableSemanticId

--- a/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/source.xml
+++ b/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/source.xml
@@ -1,15 +1,5 @@
 <eventPayload xmlns="https://admin-shell.io/aas/3/0">
-	<source>
-		<reference>
-			<type>ExternalReference</type>
-			<keys>
-				<key>
-					<type>GlobalReference</type>
-					<value>unexpected instance</value>
-				</key>
-			</keys>
-		</reference>
-	</source>
+	<source>Unexpected string value</source>
 	<sourceSemanticId>
 		<type>ModelReference</type>
 		<keys>

--- a/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/source.xml.exception
+++ b/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/source.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Reference, but got an unexpected element with the name reference at: source
+The required property Type has not been given in the XML representation of an instance of class Reference at: source

--- a/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/sourceSemanticId.xml
+++ b/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/sourceSemanticId.xml
@@ -12,17 +12,7 @@
 			</key>
 		</keys>
 	</source>
-	<sourceSemanticId>
-		<reference>
-			<type>ExternalReference</type>
-			<keys>
-				<key>
-					<type>GlobalReference</type>
-					<value>unexpected instance</value>
-				</key>
-			</keys>
-		</reference>
-	</sourceSemanticId>
+	<sourceSemanticId>Unexpected string value</sourceSemanticId>
 	<observableReference>
 		<type>ModelReference</type>
 		<keys>

--- a/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/sourceSemanticId.xml.exception
+++ b/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/sourceSemanticId.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Reference, but got an unexpected element with the name reference at: sourceSemanticId
+The required property Type has not been given in the XML representation of an instance of class Reference at: sourceSemanticId

--- a/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/subjectId.xml
+++ b/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/subjectId.xml
@@ -40,17 +40,7 @@
 		</keys>
 	</observableSemanticId>
 	<topic>something_8f13d2dd</topic>
-	<subjectId>
-		<reference>
-			<type>ExternalReference</type>
-			<keys>
-				<key>
-					<type>GlobalReference</type>
-					<value>unexpected instance</value>
-				</key>
-			</keys>
-		</reference>
-	</subjectId>
+	<subjectId>Unexpected string value</subjectId>
 	<timeStamp>2022-04-01T24:00:00-00:00</timeStamp>
 	<payload>/TsF2AbyQb1dIa0=</payload>
 </eventPayload>

--- a/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/subjectId.xml.exception
+++ b/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/subjectId.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Reference, but got an unexpected element with the name reference at: subjectId
+The required property Type has not been given in the XML representation of an instance of class Reference at: subjectId


### PR DESCRIPTION
We update the development requirements to and re-generate everything with:
* [aas-core-meta 44756fb],
* [aas-core-codegen e2b793f] and
* [aas-core3.0-testgen bf3720d7].

This is an important patch propagating in particular the following fixes which affected the constraints and their documentation:

* Pull requests in aas-core-meta [#271], [#272] and [#273] which affect the nullability checks in constraints,
* Pull request in aas-core-meta [#275] which affects the documentation of many constraints.

This patch also includes a propagation of improved test data:

* Pull request in aas-core3.0-testgen [#12] which makes the errors in XML more meaningful and easier to debug, and
* Pull request in aas-core3.0-testgen [#13] which makes the type violations of enumerations more explicit and thus easier to debug.

[aas-core-meta 44756fb]: https://github.com/aas-core-works/aas-core-meta/commit/44756fb
[aas-core-codegen e2b793f]: https://github.com/aas-core-works/aas-core-codegen/commit/e2b793f
[aas-core3.0-testgen bf3720d7]: https://github.com/aas-core-works/aas-core3.0-testgen/commit/bf3720d7

[#271]: https://github.com/aas-core-works/aas-core-meta/pull/271
[#272]: https://github.com/aas-core-works/aas-core-meta/pull/272
[#273]: https://github.com/aas-core-works/aas-core-meta/pull/273
[#275]: https://github.com/aas-core-works/aas-core-meta/pull/275

[#12]: https://github.com/aas-core-works/aas-core3.0-testgen/pull/12
[#13]: https://github.com/aas-core-works/aas-core3.0-testgen/pull/13