### PR TITLE
Release 1.0.0-rc3

### DIFF
--- a/doc/source/change_log.md
+++ b/doc/source/change_log.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## 1.0.0-rc3
+
+* Report unexpected text in XML sequences (#19)
+* Update to aas-core-meta, codegen, testgen 44756fb, e2b793f, 
+  bf3720d7 (#18)
+  * This is an important patch propagating in particular the following
+    fixes which affected the constraints and their documentation:
+  * Pull requests in aas-core-meta 271, 272 and 273 which
+    affect the nullability checks in constraints,
+  * Pull request in aas-core-meta 275 which affects
+    the documentation of many constraints.
+
 ## 1.0.0-rc2
 
 * Refactor unwrapper from enhancer (#12)

--- a/src/AasCore.Aas3_0/AasCore.Aas3_0.csproj
+++ b/src/AasCore.Aas3_0/AasCore.Aas3_0.csproj
@@ -7,7 +7,7 @@
     <LangVersion>8</LangVersion>
 
     <PackageId>AasCore.Aas3_0</PackageId>
-    <Version>1.0.0-rc2</Version>
+    <Version>1.0.0-rc3</Version>
     <Authors>Marko Ristin</Authors>
     <Description>
         An SDK for manipulating, verifying and de/serializing Asset Administration Shells.


### PR DESCRIPTION
* Report unexpected test in XML sequences (#19)
* Update to aas-core-meta, codegen, testgen 44756fb, e2b793f, bf3720d7 (#18)
  * This is an important patch propagating in particular the following fixes which affected the constraints and their documentation:
  * Pull requests in aas-core-meta [#271], [#272] and [#273] which affect the nullability checks in constraints,
  * Pull request in aas-core-meta [#275] which affects the documentation of many constraints.