### PR TITLE
Update to aas-core-meta, codegen, testgen 4d7e59e, f3d9538, 9b43de2e

### DIFF
--- a/dev_scripts/aas_core3/__init__.py
+++ b/dev_scripts/aas_core3/__init__.py
@@ -3,5 +3,5 @@ Provide Python SDK as copied from aas-core-codegen test data.
 
 This copy is necessary so that we can decouple from ``aas-core*-python`` repository.
 
-The revision of aas-core-codegen was: e2b793f
+The revision of aas-core-codegen was: f3d9538
 """

--- a/dev_scripts/aas_core3/verification.py
+++ b/dev_scripts/aas_core3/verification.py
@@ -2461,15 +2461,12 @@ class _Transformer(
                 (
                 (
                     (that.global_asset_id is not None)
-                    and (that.specific_asset_ids is None)
+                    or (that.specific_asset_ids is not None)
                 )
             )
-                or (
-                    (
-                        (that.global_asset_id is None)
-                        and (that.specific_asset_ids is not None)
-                        and len(that.specific_asset_ids) >= 1
-                    )
+                and (
+                    not (that.specific_asset_ids is not None)
+                    or (len(that.specific_asset_ids) >= 1)
                 )
             )
         ):
@@ -8062,21 +8059,10 @@ class _Transformer(
             that: aas_types.DataSpecificationIEC61360
     ) -> Iterator[Error]:
         if not (
-            (
-                (
-                (
-                    (that.value is not None)
-                    and (that.value_list is None)
-                )
-            )
-                or (
-                    (
-                        (that.value is None)
-                        and (that.value_list is not None)
-                        and len(that.value_list.value_reference_pairs) >= 1
-                    )
-                )
-            )
+            not ((
+                (that.value is not None)
+                and (that.value_list is not None)
+            ))
         ):
             yield Error(
                 'Constraint AASc-3a-010: If value is not empty then value ' +

--- a/dev_scripts/setup.py
+++ b/dev_scripts/setup.py
@@ -28,8 +28,8 @@ setup(
     keywords="asset administration shell code generation industry 4.0 industrie i4.0",
     packages=find_packages(exclude=["tests", "continuous_integration", "dev_scripts"]),
     install_requires=[
-        "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@44756fb#egg=aas-core-meta",
-        "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@e2b793f#egg=aas-core-codegen",
+        "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@4d7e59e#egg=aas-core-meta",
+        "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@f3d9538#egg=aas-core-codegen",
     ],
     py_modules=["test_codegen"],
 )

--- a/src/AasCore.Aas3_0/verification.cs
+++ b/src/AasCore.Aas3_0/verification.cs
@@ -3265,12 +3265,11 @@ namespace AasCore.Aas3_0
                 if (!(
                     (
                         (that.GlobalAssetId != null)
-                        && (that.SpecificAssetIds == null)
+                        || (that.SpecificAssetIds != null)
                     )
-                    || (
-                        (that.GlobalAssetId == null)
-                        && (that.SpecificAssetIds != null)
-                        && that.SpecificAssetIds.Count >= 1
+                    && (
+                        !(that.SpecificAssetIds != null)
+                        || (that.SpecificAssetIds.Count >= 1)
                     )))
                 {
                     yield return new Reporting.Error(
@@ -9297,15 +9296,8 @@ namespace AasCore.Aas3_0
             )
             {
                 if (!(
-                    (
-                        (that.Value != null)
-                        && (that.ValueList == null)
-                    )
-                    || (
-                        (that.Value == null)
-                        && (that.ValueList != null)
-                        && that.ValueList.ValueReferencePairs.Count >= 1
-                    )))
+                    !((that.Value != null)
+                    && (that.ValueList != null))))
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +

--- a/src/AasCore.Aas3_0/visitation.cs
+++ b/src/AasCore.Aas3_0/visitation.cs
@@ -867,7 +867,7 @@ namespace AasCore.Aas3_0
         public abstract class AbstractVisitorWithContext<TContext>
             : IVisitorWithContext<TContext>
         {
-            public void Visit(IClass that, TContext context)
+            public virtual void Visit(IClass that, TContext context)
             {
                 that.Accept(this, context);
             }
@@ -1161,7 +1161,7 @@ namespace AasCore.Aas3_0
         /// <typeparam name="T">The type of the transformation result</typeparam>
         public abstract class AbstractTransformer<T> : ITransformer<T>
         {
-            public T Transform(IClass that)
+            public virtual T Transform(IClass that)
             {
                 return that.Transform(this);
             }
@@ -1501,7 +1501,7 @@ namespace AasCore.Aas3_0
         public abstract class AbstractTransformerWithContext<TContext, T>
             : ITransformerWithContext<TContext, T>
         {
-            public T Transform(IClass that, TContext context)
+            public virtual T Transform(IClass that, TContext context)
             {
                 return that.Transform(this, context);
             }

--- a/test_data/Json/ContainedInEnvironment/Unexpected/MinLengthViolation/ValueList/valueReferencePairs.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/MinLengthViolation/ValueList/valueReferencePairs.json.errors
@@ -1,4 +1,2 @@
-assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent: Invariant violated:
-Constraint AASc-3a-010: If value is not empty then value list shall be empty and vice versa.;
 assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.valueList: Invariant violated:
 Value reference pair types must contain at least one item.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/MinLengthViolation/valueList/valueReferencePairs.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/MinLengthViolation/valueList/valueReferencePairs.xml.errors
@@ -1,4 +1,2 @@
-assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent: Invariant violated:
-Constraint AASc-3a-010: If value is not empty then value list shall be empty and vice versa.;
 assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.valueList: Invariant violated:
 Value reference pair types must contain at least one item.


### PR DESCRIPTION
We update the development requirements to and re-generate everything with:
* [aas-core-meta 4d7e59e],
* [aas-core-codegen f3d9538] and
* [aas-core3.0-testgen 9b43de2e].

Notably, this includes two important fixes propagated from aas-core-meta:

* [V3 Fix AASc-3a-010-for-NAND (#281)], and
* [V3 Fix inclusive OR in AASd-131 (#280)].

... and the following patch in aas-core-codegen:

* [Make visitation dispatches virtual in C# (#399)]

[aas-core-meta 4d7e59e]: https://github.com/aas-core-works/aas-core-meta/commit/4d7e59e
[aas-core-codegen f3d9538]: https://github.com/aas-core-works/aas-core-codegen/commit/f3d9538
[aas-core3.0-testgen 9b43de2e]: https://github.com/aas-core-works/aas-core3.0-testgen/commit/9b43de2e
[V3 Fix AASc-3a-010-for-NAND (#281)]: https://github.com/aas-core-works/aas-core-meta/pull/281
[V3 Fix inclusive OR in AASd-131 (#280)]: https://github.com/aas-core-works/aas-core-meta/pull/280
[Make visitation dispatches virtual in C# (#399)]: https://github.com/aas-core-works/aas-core-codegen/pull/399