### PR TITLE
Fix error message in xmlization on XML declaration

### DIFF
--- a/src/AasCore.Aas3_0.Tests/TestXmlizationErrors.cs
+++ b/src/AasCore.Aas3_0.Tests/TestXmlizationErrors.cs
@@ -1,0 +1,55 @@
+﻿using Aas = AasCore.Aas3_0; // renamed
+
+using NUnit.Framework; // can't alias
+
+namespace AasCore.Aas3_0.Tests
+{
+    public class TestXmlizationErrors
+    {
+        [Test]
+        public void Test_error_on_unexpected_declaration()
+        {
+            var text = (
+                "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
+                "<environment xmlns=\"https://admin-shell.io/aas/3/0\">" +
+                "<submodels><submodel>" +
+                "<id>some-unique-global-identifier</id>" +
+                "<submodelElements><property><idShort>someProperty</idShort>" +
+                "<valueType>xs:boolean</valueType></property></submodelElements>" +
+                "</submodel></submodels></environment>"
+            );
+
+            using var stringReader = new System.IO.StringReader(
+                text);
+
+            using var xmlReader = System.Xml.XmlReader.Create(
+                stringReader);
+
+            // We intentionally do not call `MoveToContent` to test the error message.
+            // This is a very common situation, see:
+            // https://github.com/aas-core-works/aas-core3.0-csharp/issues/24
+
+            string? message = null;
+
+            try
+            {
+                Aas.Xmlization.Deserialize.EnvironmentFrom(
+                    xmlReader);
+            }
+            catch (AasCore.Aas3_0.Xmlization.Exception exception)
+            {
+                message = exception.Message;
+            }
+
+            if (message == null)
+            {
+                throw new AssertionException("Unexpected no exception");
+            }
+            Assert.AreEqual(
+                "Unexpected XML declaration when reading an instance of " +
+                "class Environment, as we expect the reader to be set at content " +
+                "with MoveToContent at: the beginning",
+                message);
+        }
+    }
+}

--- a/src/AasCore.Aas3_0/xmlization.cs
+++ b/src/AasCore.Aas3_0/xmlization.cs
@@ -19876,7 +19876,7 @@ namespace AasCore.Aas3_0
             public readonly string Path;
             public readonly string Cause;
             public Exception(string path, string cause)
-                : base($"{cause} at: {path}")
+                : base($"{cause} at: {(path == "" ? "the beginning" : path)}")
             {
                 Path = path;
                 Cause = cause;
@@ -19918,6 +19918,17 @@ namespace AasCore.Aas3_0
             public static Aas.IHasSemantics IHasSemanticsFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class IHasSemantics, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.IHasSemantics? result = (
                     DeserializeImplementation.IHasSemanticsFromElement(
                         reader,
@@ -19944,6 +19955,17 @@ namespace AasCore.Aas3_0
             public static Aas.Extension ExtensionFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class Extension, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.Extension? result = (
                     DeserializeImplementation.ExtensionFromElement(
                         reader,
@@ -19971,6 +19993,17 @@ namespace AasCore.Aas3_0
             public static Aas.IHasExtensions IHasExtensionsFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class IHasExtensions, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.IHasExtensions? result = (
                     DeserializeImplementation.IHasExtensionsFromElement(
                         reader,
@@ -19998,6 +20031,17 @@ namespace AasCore.Aas3_0
             public static Aas.IReferable IReferableFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class IReferable, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.IReferable? result = (
                     DeserializeImplementation.IReferableFromElement(
                         reader,
@@ -20025,6 +20069,17 @@ namespace AasCore.Aas3_0
             public static Aas.IIdentifiable IIdentifiableFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class IIdentifiable, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.IIdentifiable? result = (
                     DeserializeImplementation.IIdentifiableFromElement(
                         reader,
@@ -20052,6 +20107,17 @@ namespace AasCore.Aas3_0
             public static Aas.IHasKind IHasKindFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class IHasKind, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.IHasKind? result = (
                     DeserializeImplementation.IHasKindFromElement(
                         reader,
@@ -20079,6 +20145,17 @@ namespace AasCore.Aas3_0
             public static Aas.IHasDataSpecification IHasDataSpecificationFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class IHasDataSpecification, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.IHasDataSpecification? result = (
                     DeserializeImplementation.IHasDataSpecificationFromElement(
                         reader,
@@ -20105,6 +20182,17 @@ namespace AasCore.Aas3_0
             public static Aas.AdministrativeInformation AdministrativeInformationFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class AdministrativeInformation, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.AdministrativeInformation? result = (
                     DeserializeImplementation.AdministrativeInformationFromElement(
                         reader,
@@ -20132,6 +20220,17 @@ namespace AasCore.Aas3_0
             public static Aas.IQualifiable IQualifiableFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class IQualifiable, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.IQualifiable? result = (
                     DeserializeImplementation.IQualifiableFromElement(
                         reader,
@@ -20158,6 +20257,17 @@ namespace AasCore.Aas3_0
             public static Aas.Qualifier QualifierFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class Qualifier, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.Qualifier? result = (
                     DeserializeImplementation.QualifierFromElement(
                         reader,
@@ -20184,6 +20294,17 @@ namespace AasCore.Aas3_0
             public static Aas.AssetAdministrationShell AssetAdministrationShellFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class AssetAdministrationShell, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.AssetAdministrationShell? result = (
                     DeserializeImplementation.AssetAdministrationShellFromElement(
                         reader,
@@ -20210,6 +20331,17 @@ namespace AasCore.Aas3_0
             public static Aas.AssetInformation AssetInformationFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class AssetInformation, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.AssetInformation? result = (
                     DeserializeImplementation.AssetInformationFromElement(
                         reader,
@@ -20236,6 +20368,17 @@ namespace AasCore.Aas3_0
             public static Aas.Resource ResourceFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class Resource, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.Resource? result = (
                     DeserializeImplementation.ResourceFromElement(
                         reader,
@@ -20262,6 +20405,17 @@ namespace AasCore.Aas3_0
             public static Aas.SpecificAssetId SpecificAssetIdFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class SpecificAssetId, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.SpecificAssetId? result = (
                     DeserializeImplementation.SpecificAssetIdFromElement(
                         reader,
@@ -20288,6 +20442,17 @@ namespace AasCore.Aas3_0
             public static Aas.Submodel SubmodelFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class Submodel, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.Submodel? result = (
                     DeserializeImplementation.SubmodelFromElement(
                         reader,
@@ -20315,6 +20480,17 @@ namespace AasCore.Aas3_0
             public static Aas.ISubmodelElement ISubmodelElementFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class ISubmodelElement, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.ISubmodelElement? result = (
                     DeserializeImplementation.ISubmodelElementFromElement(
                         reader,
@@ -20342,6 +20518,17 @@ namespace AasCore.Aas3_0
             public static Aas.IRelationshipElement IRelationshipElementFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class IRelationshipElement, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.IRelationshipElement? result = (
                     DeserializeImplementation.IRelationshipElementFromElement(
                         reader,
@@ -20368,6 +20555,17 @@ namespace AasCore.Aas3_0
             public static Aas.RelationshipElement RelationshipElementFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class RelationshipElement, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.RelationshipElement? result = (
                     DeserializeImplementation.RelationshipElementFromElement(
                         reader,
@@ -20394,6 +20592,17 @@ namespace AasCore.Aas3_0
             public static Aas.SubmodelElementList SubmodelElementListFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class SubmodelElementList, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.SubmodelElementList? result = (
                     DeserializeImplementation.SubmodelElementListFromElement(
                         reader,
@@ -20420,6 +20629,17 @@ namespace AasCore.Aas3_0
             public static Aas.SubmodelElementCollection SubmodelElementCollectionFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class SubmodelElementCollection, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.SubmodelElementCollection? result = (
                     DeserializeImplementation.SubmodelElementCollectionFromElement(
                         reader,
@@ -20447,6 +20667,17 @@ namespace AasCore.Aas3_0
             public static Aas.IDataElement IDataElementFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class IDataElement, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.IDataElement? result = (
                     DeserializeImplementation.IDataElementFromElement(
                         reader,
@@ -20473,6 +20704,17 @@ namespace AasCore.Aas3_0
             public static Aas.Property PropertyFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class Property, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.Property? result = (
                     DeserializeImplementation.PropertyFromElement(
                         reader,
@@ -20499,6 +20741,17 @@ namespace AasCore.Aas3_0
             public static Aas.MultiLanguageProperty MultiLanguagePropertyFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class MultiLanguageProperty, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.MultiLanguageProperty? result = (
                     DeserializeImplementation.MultiLanguagePropertyFromElement(
                         reader,
@@ -20525,6 +20778,17 @@ namespace AasCore.Aas3_0
             public static Aas.Range RangeFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class Range, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.Range? result = (
                     DeserializeImplementation.RangeFromElement(
                         reader,
@@ -20551,6 +20815,17 @@ namespace AasCore.Aas3_0
             public static Aas.ReferenceElement ReferenceElementFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class ReferenceElement, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.ReferenceElement? result = (
                     DeserializeImplementation.ReferenceElementFromElement(
                         reader,
@@ -20577,6 +20852,17 @@ namespace AasCore.Aas3_0
             public static Aas.Blob BlobFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class Blob, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.Blob? result = (
                     DeserializeImplementation.BlobFromElement(
                         reader,
@@ -20603,6 +20889,17 @@ namespace AasCore.Aas3_0
             public static Aas.File FileFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class File, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.File? result = (
                     DeserializeImplementation.FileFromElement(
                         reader,
@@ -20629,6 +20926,17 @@ namespace AasCore.Aas3_0
             public static Aas.AnnotatedRelationshipElement AnnotatedRelationshipElementFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class AnnotatedRelationshipElement, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.AnnotatedRelationshipElement? result = (
                     DeserializeImplementation.AnnotatedRelationshipElementFromElement(
                         reader,
@@ -20655,6 +20963,17 @@ namespace AasCore.Aas3_0
             public static Aas.Entity EntityFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class Entity, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.Entity? result = (
                     DeserializeImplementation.EntityFromElement(
                         reader,
@@ -20681,6 +21000,17 @@ namespace AasCore.Aas3_0
             public static Aas.EventPayload EventPayloadFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class EventPayload, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.EventPayload? result = (
                     DeserializeImplementation.EventPayloadFromElement(
                         reader,
@@ -20708,6 +21038,17 @@ namespace AasCore.Aas3_0
             public static Aas.IEventElement IEventElementFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class IEventElement, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.IEventElement? result = (
                     DeserializeImplementation.IEventElementFromElement(
                         reader,
@@ -20734,6 +21075,17 @@ namespace AasCore.Aas3_0
             public static Aas.BasicEventElement BasicEventElementFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class BasicEventElement, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.BasicEventElement? result = (
                     DeserializeImplementation.BasicEventElementFromElement(
                         reader,
@@ -20760,6 +21112,17 @@ namespace AasCore.Aas3_0
             public static Aas.Operation OperationFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class Operation, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.Operation? result = (
                     DeserializeImplementation.OperationFromElement(
                         reader,
@@ -20786,6 +21149,17 @@ namespace AasCore.Aas3_0
             public static Aas.OperationVariable OperationVariableFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class OperationVariable, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.OperationVariable? result = (
                     DeserializeImplementation.OperationVariableFromElement(
                         reader,
@@ -20812,6 +21186,17 @@ namespace AasCore.Aas3_0
             public static Aas.Capability CapabilityFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class Capability, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.Capability? result = (
                     DeserializeImplementation.CapabilityFromElement(
                         reader,
@@ -20838,6 +21223,17 @@ namespace AasCore.Aas3_0
             public static Aas.ConceptDescription ConceptDescriptionFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class ConceptDescription, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.ConceptDescription? result = (
                     DeserializeImplementation.ConceptDescriptionFromElement(
                         reader,
@@ -20864,6 +21260,17 @@ namespace AasCore.Aas3_0
             public static Aas.Reference ReferenceFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class Reference, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.Reference? result = (
                     DeserializeImplementation.ReferenceFromElement(
                         reader,
@@ -20890,6 +21297,17 @@ namespace AasCore.Aas3_0
             public static Aas.Key KeyFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class Key, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.Key? result = (
                     DeserializeImplementation.KeyFromElement(
                         reader,
@@ -20917,6 +21335,17 @@ namespace AasCore.Aas3_0
             public static Aas.IAbstractLangString IAbstractLangStringFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class IAbstractLangString, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.IAbstractLangString? result = (
                     DeserializeImplementation.IAbstractLangStringFromElement(
                         reader,
@@ -20943,6 +21372,17 @@ namespace AasCore.Aas3_0
             public static Aas.LangStringNameType LangStringNameTypeFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class LangStringNameType, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.LangStringNameType? result = (
                     DeserializeImplementation.LangStringNameTypeFromElement(
                         reader,
@@ -20969,6 +21409,17 @@ namespace AasCore.Aas3_0
             public static Aas.LangStringTextType LangStringTextTypeFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class LangStringTextType, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.LangStringTextType? result = (
                     DeserializeImplementation.LangStringTextTypeFromElement(
                         reader,
@@ -20995,6 +21446,17 @@ namespace AasCore.Aas3_0
             public static Aas.Environment EnvironmentFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class Environment, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.Environment? result = (
                     DeserializeImplementation.EnvironmentFromElement(
                         reader,
@@ -21022,6 +21484,17 @@ namespace AasCore.Aas3_0
             public static Aas.IDataSpecificationContent IDataSpecificationContentFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class IDataSpecificationContent, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.IDataSpecificationContent? result = (
                     DeserializeImplementation.IDataSpecificationContentFromElement(
                         reader,
@@ -21048,6 +21521,17 @@ namespace AasCore.Aas3_0
             public static Aas.EmbeddedDataSpecification EmbeddedDataSpecificationFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class EmbeddedDataSpecification, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.EmbeddedDataSpecification? result = (
                     DeserializeImplementation.EmbeddedDataSpecificationFromElement(
                         reader,
@@ -21074,6 +21558,17 @@ namespace AasCore.Aas3_0
             public static Aas.LevelType LevelTypeFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class LevelType, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.LevelType? result = (
                     DeserializeImplementation.LevelTypeFromElement(
                         reader,
@@ -21100,6 +21595,17 @@ namespace AasCore.Aas3_0
             public static Aas.ValueReferencePair ValueReferencePairFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class ValueReferencePair, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.ValueReferencePair? result = (
                     DeserializeImplementation.ValueReferencePairFromElement(
                         reader,
@@ -21126,6 +21632,17 @@ namespace AasCore.Aas3_0
             public static Aas.ValueList ValueListFrom(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class ValueList, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.ValueList? result = (
                     DeserializeImplementation.ValueListFromElement(
                         reader,
@@ -21152,6 +21669,17 @@ namespace AasCore.Aas3_0
             public static Aas.LangStringPreferredNameTypeIec61360 LangStringPreferredNameTypeIec61360From(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class LangStringPreferredNameTypeIec61360, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.LangStringPreferredNameTypeIec61360? result = (
                     DeserializeImplementation.LangStringPreferredNameTypeIec61360FromElement(
                         reader,
@@ -21178,6 +21706,17 @@ namespace AasCore.Aas3_0
             public static Aas.LangStringShortNameTypeIec61360 LangStringShortNameTypeIec61360From(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class LangStringShortNameTypeIec61360, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.LangStringShortNameTypeIec61360? result = (
                     DeserializeImplementation.LangStringShortNameTypeIec61360FromElement(
                         reader,
@@ -21204,6 +21743,17 @@ namespace AasCore.Aas3_0
             public static Aas.LangStringDefinitionTypeIec61360 LangStringDefinitionTypeIec61360From(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class LangStringDefinitionTypeIec61360, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.LangStringDefinitionTypeIec61360? result = (
                     DeserializeImplementation.LangStringDefinitionTypeIec61360FromElement(
                         reader,
@@ -21230,6 +21780,17 @@ namespace AasCore.Aas3_0
             public static Aas.DataSpecificationIec61360 DataSpecificationIec61360From(
                 Xml.XmlReader reader)
             {
+                DeserializeImplementation.SkipNoneWhitespaceAndComments(reader);
+
+                if (!reader.EOF && reader.NodeType == Xml.XmlNodeType.XmlDeclaration)
+                {
+                    throw new Xmlization.Exception(
+                        "",
+                        "Unexpected XML declaration when reading an instance " +
+                        "of class DataSpecificationIec61360, as we expect the reader " +
+                        "to be set at content with MoveToContent");
+                }
+
                 Aas.DataSpecificationIec61360? result = (
                     DeserializeImplementation.DataSpecificationIec61360FromElement(
                         reader,

--- a/src/aas-core3.0-csharp.sln.DotSettings.user
+++ b/src/aas-core3.0-csharp.sln.DotSettings.user
@@ -1,8 +1,31 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=2dc3e0f3_002Dd11c_002D43a0_002Da69b_002D36aeb637f0cd/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" Name="Test_error_on_unexpected_declaration" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
+  &lt;TestAncestor&gt;&#xD;
+    &lt;TestId&gt;NUnit3x::BDA0E5A2-D48D-4888-9D52-44BD529F8108::net6.0::AasCore.Aas3_0.Tests.TestXmlizationErrors.Test_error_on_unexpected_declaration&lt;/TestId&gt;&#xD;
+  &lt;/TestAncestor&gt;&#xD;
+&lt;/SessionState&gt;</s:String>
 	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=bd994a3b_002D4a4e_002D4b0b_002D90d4_002Ddfcb614164d9/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="Test_XML_serialization" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
+  &lt;Or&gt;&#xD;
+    &lt;ProjectFile&gt;BDA0E5A2-D48D-4888-9D52-44BD529F8108/f:TestXmlizationOfConcreteClasses.cs&lt;/ProjectFile&gt;&#xD;
+    &lt;ProjectFile&gt;BDA0E5A2-D48D-4888-9D52-44BD529F8108/f:TestXmlizationOfConcreteClassesOutsideContainer.cs&lt;/ProjectFile&gt;&#xD;
+    &lt;ProjectFile&gt;BDA0E5A2-D48D-4888-9D52-44BD529F8108/f:TestXmlizationOfInterfaces.cs&lt;/ProjectFile&gt;&#xD;
+    &lt;TestAncestor&gt;&#xD;
+      &lt;TestId&gt;NUnit3x::BDA0E5A2-D48D-4888-9D52-44BD529F8108::net6.0::AasCore.Aas3_0.Tests.TestExamples.Test_XML_serialization&lt;/TestId&gt;&#xD;
+      &lt;TestId&gt;NUnit3x::BDA0E5A2-D48D-4888-9D52-44BD529F8108::net6.0::AasCore.Aas3_0.Tests.TestExamples.Test_JSON_deserialization&lt;/TestId&gt;&#xD;
+      &lt;TestId&gt;NUnit3x::BDA0E5A2-D48D-4888-9D52-44BD529F8108::net6.0::AasCore.Aas3_0.Tests.TestExamples.Test_selective_enhancing&lt;/TestId&gt;&#xD;
+      &lt;TestId&gt;NUnit3x::BDA0E5A2-D48D-4888-9D52-44BD529F8108::net6.0::AasCore.Aas3_0.Tests.TestXmlizationErrors.Test_error_on_unexpected_declaration&lt;/TestId&gt;&#xD;
+    &lt;/TestAncestor&gt;&#xD;
+  &lt;/Or&gt;&#xD;
+&lt;/SessionState&gt;</s:String>
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=d08349d0_002D1d79_002D48ae_002D9b89_002D73f1b5254923/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" Name="Test_XML_serialization #2" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
   &lt;TestAncestor&gt;&#xD;
     &lt;TestId&gt;NUnit3x::BDA0E5A2-D48D-4888-9D52-44BD529F8108::net6.0::AasCore.Aas3_0.Tests.TestExamples.Test_XML_serialization&lt;/TestId&gt;&#xD;
     &lt;TestId&gt;NUnit3x::BDA0E5A2-D48D-4888-9D52-44BD529F8108::net6.0::AasCore.Aas3_0.Tests.TestExamples.Test_JSON_deserialization&lt;/TestId&gt;&#xD;
     &lt;TestId&gt;NUnit3x::BDA0E5A2-D48D-4888-9D52-44BD529F8108::net6.0::AasCore.Aas3_0.Tests.TestExamples.Test_selective_enhancing&lt;/TestId&gt;&#xD;
+    &lt;TestId&gt;NUnit3x::BDA0E5A2-D48D-4888-9D52-44BD529F8108::net6.0::AasCore.Aas3_0.Tests.TestXmlizationErrors.Test_error_on_unexpected_declaration&lt;/TestId&gt;&#xD;
   &lt;/TestAncestor&gt;&#xD;
-&lt;/SessionState&gt;</s:String></wpf:ResourceDictionary>
+&lt;/SessionState&gt;</s:String>
+	
+	<s:String x:Key="/Default/Housekeeping/UnitTestingMru/UnitTestRunner/EnvironmentVariablesIndexed/=AAS_005FCORE_005FAAS3_005F0_005FTESTS_005FRECORD_005FMODE/@EntryIndexedValue">true</s:String>
+	<s:String x:Key="/Default/Housekeeping/UnitTestingMru/UnitTestRunner/EnvironmentVariablesIndexed/=AAS_005FCORE_005FAAS3_005F0_005FTESTS_005FTEST_005FDATA_005FDIR/@EntryIndexedValue">C:\Users\rist\workspace\aas-core-works\aas-core3.0-csharp\test_data</s:String>
+	<s:String x:Key="/Default/Housekeeping/UnitTestingMru/UnitTestRunner/RunConfigurationFilename/@EntryValue">C:\Users\rist\workspace\aas-core-works\aas-core3.0-cli-swiss-knife\mristin.runsettings</s:String></wpf:ResourceDictionary>

--- a/test_data/Xml/SelfContained/Unexpected/RequiredViolation/eventPayload/observableReference.xml.exception
+++ b/test_data/Xml/SelfContained/Unexpected/RequiredViolation/eventPayload/observableReference.xml.exception
@@ -1,1 +1,1 @@
-The required property ObservableReference has not been given in the XML representation of an instance of class EventPayload at: 
+The required property ObservableReference has not been given in the XML representation of an instance of class EventPayload at: the beginning

--- a/test_data/Xml/SelfContained/Unexpected/RequiredViolation/eventPayload/source.xml.exception
+++ b/test_data/Xml/SelfContained/Unexpected/RequiredViolation/eventPayload/source.xml.exception
@@ -1,1 +1,1 @@
-The required property Source has not been given in the XML representation of an instance of class EventPayload at: 
+The required property Source has not been given in the XML representation of an instance of class EventPayload at: the beginning

--- a/test_data/Xml/SelfContained/Unexpected/RequiredViolation/eventPayload/timeStamp.xml.exception
+++ b/test_data/Xml/SelfContained/Unexpected/RequiredViolation/eventPayload/timeStamp.xml.exception
@@ -1,1 +1,1 @@
-The required property TimeStamp has not been given in the XML representation of an instance of class EventPayload at: 
+The required property TimeStamp has not been given in the XML representation of an instance of class EventPayload at: the beginning

--- a/test_data/Xml/SelfContained/Unexpected/TypeViolation/environment/assetAdministrationShells.xml.exception
+++ b/test_data/Xml/SelfContained/Unexpected/TypeViolation/environment/assetAdministrationShells.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Environment with the element name assetAdministrationShells, but got the node of type Text with the value Unexpected string value at: 
+Expected an XML end element to conclude a property of class Environment with the element name assetAdministrationShells, but got the node of type Text with the value Unexpected string value at: the beginning

--- a/test_data/Xml/SelfContained/Unexpected/TypeViolation/environment/conceptDescriptions.xml.exception
+++ b/test_data/Xml/SelfContained/Unexpected/TypeViolation/environment/conceptDescriptions.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Environment with the element name conceptDescriptions, but got the node of type Text with the value Unexpected string value at: 
+Expected an XML end element to conclude a property of class Environment with the element name conceptDescriptions, but got the node of type Text with the value Unexpected string value at: the beginning

--- a/test_data/Xml/SelfContained/Unexpected/TypeViolation/environment/submodels.xml.exception
+++ b/test_data/Xml/SelfContained/Unexpected/TypeViolation/environment/submodels.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class Environment with the element name submodels, but got the node of type Text with the value Unexpected string value at: 
+Expected an XML end element to conclude a property of class Environment with the element name submodels, but got the node of type Text with the value Unexpected string value at: the beginning

--- a/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/payload.xml.exception
+++ b/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/payload.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class EventPayload with the element name payload, but got the node of type Element with the value  at: 
+Expected an XML end element to conclude a property of class EventPayload with the element name payload, but got the node of type Element with the value  at: the beginning

--- a/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/timeStamp.xml.exception
+++ b/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/timeStamp.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class EventPayload with the element name timeStamp, but got the node of type Element with the value  at: 
+Expected an XML end element to conclude a property of class EventPayload with the element name timeStamp, but got the node of type Element with the value  at: the beginning

--- a/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/topic.xml.exception
+++ b/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/topic.xml.exception
@@ -1,1 +1,1 @@
-Expected an XML end element to conclude a property of class EventPayload with the element name topic, but got the node of type Element with the value  at: 
+Expected an XML end element to conclude a property of class EventPayload with the element name topic, but got the node of type Element with the value  at: the beginning

--- a/test_data/Xml/SelfContained/Unexpected/UnexpectedAdditionalProperty/environment/invalid.xml.exception
+++ b/test_data/Xml/SelfContained/Unexpected/UnexpectedAdditionalProperty/environment/invalid.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class Environment, but got an unexpected element with the name unexpectedAdditionalProperty at: 
+We expected properties of the class Environment, but got an unexpected element with the name unexpectedAdditionalProperty at: the beginning

--- a/test_data/Xml/SelfContained/Unexpected/UnexpectedAdditionalProperty/eventPayload/invalid.xml.exception
+++ b/test_data/Xml/SelfContained/Unexpected/UnexpectedAdditionalProperty/eventPayload/invalid.xml.exception
@@ -1,1 +1,1 @@
-We expected properties of the class EventPayload, but got an unexpected element with the name unexpectedAdditionalProperty at: 
+We expected properties of the class EventPayload, but got an unexpected element with the name unexpectedAdditionalProperty at: the beginning


### PR DESCRIPTION
When we encountered XML declarations, we threw exceptions with uninformative messages. Namely, we expect the reader to be moved to the content, but most users omitted to read that in the documentation.

We refine the error message for this particular situation, and hint at `MoveToContent` method on the reader.

Fixes #24.

Generated with [aas-core-codegen 28fbd98].

[aas-core-codegen 28fbd98]: https://github.com/aas-core-works/aas-core-codegen/commit/28fbd98