### PR TITLE
Release 1.0.1

### DIFF
--- a/doc/source/change_log.md
+++ b/doc/source/change_log.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.0.1 (2024-03-13)
+
+This patch release brings about the fix for patterns concerning dates and
+date-times with zone offset `14:00` which previously allowed for
+a concatenation without a plus sign.
+
 ## 1.0.0 (2024-02-02)
 
 This is the first stable release. The release candidates stood

--- a/src/AasCore.Aas3_0/AasCore.Aas3_0.csproj
+++ b/src/AasCore.Aas3_0/AasCore.Aas3_0.csproj
@@ -7,7 +7,7 @@
     <LangVersion>8</LangVersion>
 
     <PackageId>AasCore.Aas3_0</PackageId>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <Authors>Marko Ristin</Authors>
     <Description>
         An SDK for manipulating, verifying and de/serializing Asset Administration Shells.


### PR DESCRIPTION
This patch release brings about the fix for patterns concerning dates and date-times with zone offset `14:00` which previously allowed for a concatenation without a plus sign.