### PR TITLE
Release 1.0.2

### DIFF
--- a/doc/source/change_log.md
+++ b/doc/source/change_log.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.0.2 (2024-03-23)
+
+In this patch version, we propagate the fix from abnf-to-regex related
+to maximum qualifiers which had been mistakenly represented as exact
+repetition before.
+
 ## 1.0.1 (2024-03-13)
 
 This patch release brings about the fix for patterns concerning dates and

--- a/src/AasCore.Aas3_0/AasCore.Aas3_0.csproj
+++ b/src/AasCore.Aas3_0/AasCore.Aas3_0.csproj
@@ -7,7 +7,7 @@
     <LangVersion>8</LangVersion>
 
     <PackageId>AasCore.Aas3_0</PackageId>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <Authors>Marko Ristin</Authors>
     <Description>
         An SDK for manipulating, verifying and de/serializing Asset Administration Shells.


### PR DESCRIPTION
In this patch version, we propagate the fix from abnf-to-regex related to maximum qualifiers which had been mistakenly represented as exact repetition before.