### PR TITLE
Release 1.0.3

### DIFF
--- a/doc/source/change_log.md
+++ b/doc/source/change_log.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 1.0.3 (2024-04-16)
+
+The `dataSpecification` field in `EmbeddedDataSpecification` is made
+optional, according to the book.
+
 ## 1.0.2 (2024-03-23)
 
 In this patch version, we propagate the fix from abnf-to-regex related

--- a/src/AasCore.Aas3_0/AasCore.Aas3_0.csproj
+++ b/src/AasCore.Aas3_0/AasCore.Aas3_0.csproj
@@ -7,7 +7,7 @@
     <LangVersion>8</LangVersion>
 
     <PackageId>AasCore.Aas3_0</PackageId>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
     <Authors>Marko Ristin</Authors>
     <Description>
         An SDK for manipulating, verifying and de/serializing Asset Administration Shells.


### PR DESCRIPTION
The `dataSpecification` field in `EmbeddedDataSpecification` is made optional, according to the book.