### PR TITLE
Check explicitly for invalid model types

### DIFF
--- a/src/AasCore.Aas3_0/jsonization.cs
+++ b/src/AasCore.Aas3_0/jsonization.cs
@@ -1658,6 +1658,8 @@ namespace AasCore.Aas3_0
                 IReference? theDerivedFrom = null;
                 List<IReference>? theSubmodels = null;
 
+                string? modelType = null;
+
                 foreach (var keyValue in obj)
                 {
                     switch (keyValue.Key)
@@ -2082,7 +2084,36 @@ namespace AasCore.Aas3_0
                                 break;
                             }
                         case "modelType":
-                            continue;
+                            {
+                                if (keyValue.Value == null)
+                                {
+                                    error = new Reporting.Error(
+                                        "Expected a model type, but got null");
+                                    return null;
+                                }
+                                modelType = DeserializeImplementation.StringFrom(
+                                    keyValue.Value,
+                                    out error);
+                                if (error != null)
+                                {
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "modelType"));
+                                    return null;
+                                }
+
+                                if (modelType != "AssetAdministrationShell")
+                                {
+                                    error = new Reporting.Error(
+                                        "Expected the model type 'AssetAdministrationShell', " +
+                                        $"but got {modelType}");
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "modelType"));
+                                    return null;
+                                }
+                                break;
+                            }
                         default:
                             error = new Reporting.Error(
                                 $"Unexpected property: {keyValue.Key}");
@@ -2101,6 +2132,13 @@ namespace AasCore.Aas3_0
                 {
                     error = new Reporting.Error(
                         "Required property \"assetInformation\" is missing");
+                    return null;
+                }
+
+                if (modelType == null)
+                {
+                    error = new Reporting.Error(
+                        "Required property \"modelType\" is missing");
                     return null;
                 }
 
@@ -2697,6 +2735,8 @@ namespace AasCore.Aas3_0
                 List<IEmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
                 List<ISubmodelElement>? theSubmodelElements = null;
 
+                string? modelType = null;
+
                 foreach (var keyValue in obj)
                 {
                     switch (keyValue.Key)
@@ -3231,7 +3271,36 @@ namespace AasCore.Aas3_0
                                 break;
                             }
                         case "modelType":
-                            continue;
+                            {
+                                if (keyValue.Value == null)
+                                {
+                                    error = new Reporting.Error(
+                                        "Expected a model type, but got null");
+                                    return null;
+                                }
+                                modelType = DeserializeImplementation.StringFrom(
+                                    keyValue.Value,
+                                    out error);
+                                if (error != null)
+                                {
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "modelType"));
+                                    return null;
+                                }
+
+                                if (modelType != "Submodel")
+                                {
+                                    error = new Reporting.Error(
+                                        "Expected the model type 'Submodel', " +
+                                        $"but got {modelType}");
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "modelType"));
+                                    return null;
+                                }
+                                break;
+                            }
                         default:
                             error = new Reporting.Error(
                                 $"Unexpected property: {keyValue.Key}");
@@ -3243,6 +3312,13 @@ namespace AasCore.Aas3_0
                 {
                     error = new Reporting.Error(
                         "Required property \"id\" is missing");
+                    return null;
+                }
+
+                if (modelType == null)
+                {
+                    error = new Reporting.Error(
+                        "Required property \"modelType\" is missing");
                     return null;
                 }
 
@@ -3450,6 +3526,8 @@ namespace AasCore.Aas3_0
                 List<IReference>? theSupplementalSemanticIds = null;
                 List<IQualifier>? theQualifiers = null;
                 List<IEmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
+
+                string? modelType = null;
 
                 foreach (var keyValue in obj)
                 {
@@ -3906,7 +3984,36 @@ namespace AasCore.Aas3_0
                                 break;
                             }
                         case "modelType":
-                            continue;
+                            {
+                                if (keyValue.Value == null)
+                                {
+                                    error = new Reporting.Error(
+                                        "Expected a model type, but got null");
+                                    return null;
+                                }
+                                modelType = DeserializeImplementation.StringFrom(
+                                    keyValue.Value,
+                                    out error);
+                                if (error != null)
+                                {
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "modelType"));
+                                    return null;
+                                }
+
+                                if (modelType != "RelationshipElement")
+                                {
+                                    error = new Reporting.Error(
+                                        "Expected the model type 'RelationshipElement', " +
+                                        $"but got {modelType}");
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "modelType"));
+                                    return null;
+                                }
+                                break;
+                            }
                         default:
                             error = new Reporting.Error(
                                 $"Unexpected property: {keyValue.Key}");
@@ -3925,6 +4032,13 @@ namespace AasCore.Aas3_0
                 {
                     error = new Reporting.Error(
                         "Required property \"second\" is missing");
+                    return null;
+                }
+
+                if (modelType == null)
+                {
+                    error = new Reporting.Error(
+                        "Required property \"modelType\" is missing");
                     return null;
                 }
 
@@ -4009,6 +4123,8 @@ namespace AasCore.Aas3_0
                 IReference? theSemanticIdListElement = null;
                 DataTypeDefXsd? theValueTypeListElement = null;
                 List<ISubmodelElement>? theValue = null;
+
+                string? modelType = null;
 
                 foreach (var keyValue in obj)
                 {
@@ -4568,7 +4684,36 @@ namespace AasCore.Aas3_0
                                 break;
                             }
                         case "modelType":
-                            continue;
+                            {
+                                if (keyValue.Value == null)
+                                {
+                                    error = new Reporting.Error(
+                                        "Expected a model type, but got null");
+                                    return null;
+                                }
+                                modelType = DeserializeImplementation.StringFrom(
+                                    keyValue.Value,
+                                    out error);
+                                if (error != null)
+                                {
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "modelType"));
+                                    return null;
+                                }
+
+                                if (modelType != "SubmodelElementList")
+                                {
+                                    error = new Reporting.Error(
+                                        "Expected the model type 'SubmodelElementList', " +
+                                        $"but got {modelType}");
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "modelType"));
+                                    return null;
+                                }
+                                break;
+                            }
                         default:
                             error = new Reporting.Error(
                                 $"Unexpected property: {keyValue.Key}");
@@ -4580,6 +4725,13 @@ namespace AasCore.Aas3_0
                 {
                     error = new Reporting.Error(
                         "Required property \"typeValueListElement\" is missing");
+                    return null;
+                }
+
+                if (modelType == null)
+                {
+                    error = new Reporting.Error(
+                        "Required property \"modelType\" is missing");
                     return null;
                 }
 
@@ -4631,6 +4783,8 @@ namespace AasCore.Aas3_0
                 List<IQualifier>? theQualifiers = null;
                 List<IEmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
                 List<ISubmodelElement>? theValue = null;
+
+                string? modelType = null;
 
                 foreach (var keyValue in obj)
                 {
@@ -5094,7 +5248,36 @@ namespace AasCore.Aas3_0
                                 break;
                             }
                         case "modelType":
-                            continue;
+                            {
+                                if (keyValue.Value == null)
+                                {
+                                    error = new Reporting.Error(
+                                        "Expected a model type, but got null");
+                                    return null;
+                                }
+                                modelType = DeserializeImplementation.StringFrom(
+                                    keyValue.Value,
+                                    out error);
+                                if (error != null)
+                                {
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "modelType"));
+                                    return null;
+                                }
+
+                                if (modelType != "SubmodelElementCollection")
+                                {
+                                    error = new Reporting.Error(
+                                        "Expected the model type 'SubmodelElementCollection', " +
+                                        $"but got {modelType}");
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "modelType"));
+                                    return null;
+                                }
+                                break;
+                            }
                         default:
                             error = new Reporting.Error(
                                 $"Unexpected property: {keyValue.Key}");
@@ -5103,6 +5286,13 @@ namespace AasCore.Aas3_0
                 }
 
 
+
+                if (modelType == null)
+                {
+                    error = new Reporting.Error(
+                        "Required property \"modelType\" is missing");
+                    return null;
+                }
 
                 return new Aas.SubmodelElementCollection(
                     theExtensions,
@@ -5220,6 +5410,8 @@ namespace AasCore.Aas3_0
                 List<IEmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
                 string? theValue = null;
                 IReference? theValueId = null;
+
+                string? modelType = null;
 
                 foreach (var keyValue in obj)
                 {
@@ -5700,7 +5892,36 @@ namespace AasCore.Aas3_0
                                 break;
                             }
                         case "modelType":
-                            continue;
+                            {
+                                if (keyValue.Value == null)
+                                {
+                                    error = new Reporting.Error(
+                                        "Expected a model type, but got null");
+                                    return null;
+                                }
+                                modelType = DeserializeImplementation.StringFrom(
+                                    keyValue.Value,
+                                    out error);
+                                if (error != null)
+                                {
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "modelType"));
+                                    return null;
+                                }
+
+                                if (modelType != "Property")
+                                {
+                                    error = new Reporting.Error(
+                                        "Expected the model type 'Property', " +
+                                        $"but got {modelType}");
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "modelType"));
+                                    return null;
+                                }
+                                break;
+                            }
                         default:
                             error = new Reporting.Error(
                                 $"Unexpected property: {keyValue.Key}");
@@ -5712,6 +5933,13 @@ namespace AasCore.Aas3_0
                 {
                     error = new Reporting.Error(
                         "Required property \"valueType\" is missing");
+                    return null;
+                }
+
+                if (modelType == null)
+                {
+                    error = new Reporting.Error(
+                        "Required property \"modelType\" is missing");
                     return null;
                 }
 
@@ -5762,6 +5990,8 @@ namespace AasCore.Aas3_0
                 List<IEmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
                 List<ILangStringTextType>? theValue = null;
                 IReference? theValueId = null;
+
+                string? modelType = null;
 
                 foreach (var keyValue in obj)
                 {
@@ -6249,7 +6479,36 @@ namespace AasCore.Aas3_0
                                 break;
                             }
                         case "modelType":
-                            continue;
+                            {
+                                if (keyValue.Value == null)
+                                {
+                                    error = new Reporting.Error(
+                                        "Expected a model type, but got null");
+                                    return null;
+                                }
+                                modelType = DeserializeImplementation.StringFrom(
+                                    keyValue.Value,
+                                    out error);
+                                if (error != null)
+                                {
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "modelType"));
+                                    return null;
+                                }
+
+                                if (modelType != "MultiLanguageProperty")
+                                {
+                                    error = new Reporting.Error(
+                                        "Expected the model type 'MultiLanguageProperty', " +
+                                        $"but got {modelType}");
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "modelType"));
+                                    return null;
+                                }
+                                break;
+                            }
                         default:
                             error = new Reporting.Error(
                                 $"Unexpected property: {keyValue.Key}");
@@ -6258,6 +6517,13 @@ namespace AasCore.Aas3_0
                 }
 
 
+
+                if (modelType == null)
+                {
+                    error = new Reporting.Error(
+                        "Required property \"modelType\" is missing");
+                    return null;
+                }
 
                 return new Aas.MultiLanguageProperty(
                     theExtensions,
@@ -6304,6 +6570,8 @@ namespace AasCore.Aas3_0
                 List<IEmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
                 string? theMin = null;
                 string? theMax = null;
+
+                string? modelType = null;
 
                 foreach (var keyValue in obj)
                 {
@@ -6784,7 +7052,36 @@ namespace AasCore.Aas3_0
                                 break;
                             }
                         case "modelType":
-                            continue;
+                            {
+                                if (keyValue.Value == null)
+                                {
+                                    error = new Reporting.Error(
+                                        "Expected a model type, but got null");
+                                    return null;
+                                }
+                                modelType = DeserializeImplementation.StringFrom(
+                                    keyValue.Value,
+                                    out error);
+                                if (error != null)
+                                {
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "modelType"));
+                                    return null;
+                                }
+
+                                if (modelType != "Range")
+                                {
+                                    error = new Reporting.Error(
+                                        "Expected the model type 'Range', " +
+                                        $"but got {modelType}");
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "modelType"));
+                                    return null;
+                                }
+                                break;
+                            }
                         default:
                             error = new Reporting.Error(
                                 $"Unexpected property: {keyValue.Key}");
@@ -6796,6 +7093,13 @@ namespace AasCore.Aas3_0
                 {
                     error = new Reporting.Error(
                         "Required property \"valueType\" is missing");
+                    return null;
+                }
+
+                if (modelType == null)
+                {
+                    error = new Reporting.Error(
+                        "Required property \"modelType\" is missing");
                     return null;
                 }
 
@@ -6845,6 +7149,8 @@ namespace AasCore.Aas3_0
                 List<IQualifier>? theQualifiers = null;
                 List<IEmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
                 IReference? theValue = null;
+
+                string? modelType = null;
 
                 foreach (var keyValue in obj)
                 {
@@ -7277,7 +7583,36 @@ namespace AasCore.Aas3_0
                                 break;
                             }
                         case "modelType":
-                            continue;
+                            {
+                                if (keyValue.Value == null)
+                                {
+                                    error = new Reporting.Error(
+                                        "Expected a model type, but got null");
+                                    return null;
+                                }
+                                modelType = DeserializeImplementation.StringFrom(
+                                    keyValue.Value,
+                                    out error);
+                                if (error != null)
+                                {
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "modelType"));
+                                    return null;
+                                }
+
+                                if (modelType != "ReferenceElement")
+                                {
+                                    error = new Reporting.Error(
+                                        "Expected the model type 'ReferenceElement', " +
+                                        $"but got {modelType}");
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "modelType"));
+                                    return null;
+                                }
+                                break;
+                            }
                         default:
                             error = new Reporting.Error(
                                 $"Unexpected property: {keyValue.Key}");
@@ -7286,6 +7621,13 @@ namespace AasCore.Aas3_0
                 }
 
 
+
+                if (modelType == null)
+                {
+                    error = new Reporting.Error(
+                        "Required property \"modelType\" is missing");
+                    return null;
+                }
 
                 return new Aas.ReferenceElement(
                     theExtensions,
@@ -7330,6 +7672,8 @@ namespace AasCore.Aas3_0
                 List<IQualifier>? theQualifiers = null;
                 List<IEmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
                 byte[]? theValue = null;
+
+                string? modelType = null;
 
                 foreach (var keyValue in obj)
                 {
@@ -7786,7 +8130,36 @@ namespace AasCore.Aas3_0
                                 break;
                             }
                         case "modelType":
-                            continue;
+                            {
+                                if (keyValue.Value == null)
+                                {
+                                    error = new Reporting.Error(
+                                        "Expected a model type, but got null");
+                                    return null;
+                                }
+                                modelType = DeserializeImplementation.StringFrom(
+                                    keyValue.Value,
+                                    out error);
+                                if (error != null)
+                                {
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "modelType"));
+                                    return null;
+                                }
+
+                                if (modelType != "Blob")
+                                {
+                                    error = new Reporting.Error(
+                                        "Expected the model type 'Blob', " +
+                                        $"but got {modelType}");
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "modelType"));
+                                    return null;
+                                }
+                                break;
+                            }
                         default:
                             error = new Reporting.Error(
                                 $"Unexpected property: {keyValue.Key}");
@@ -7798,6 +8171,13 @@ namespace AasCore.Aas3_0
                 {
                     error = new Reporting.Error(
                         "Required property \"contentType\" is missing");
+                    return null;
+                }
+
+                if (modelType == null)
+                {
+                    error = new Reporting.Error(
+                        "Required property \"modelType\" is missing");
                     return null;
                 }
 
@@ -7847,6 +8227,8 @@ namespace AasCore.Aas3_0
                 List<IQualifier>? theQualifiers = null;
                 List<IEmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
                 string? theValue = null;
+
+                string? modelType = null;
 
                 foreach (var keyValue in obj)
                 {
@@ -8303,7 +8685,36 @@ namespace AasCore.Aas3_0
                                 break;
                             }
                         case "modelType":
-                            continue;
+                            {
+                                if (keyValue.Value == null)
+                                {
+                                    error = new Reporting.Error(
+                                        "Expected a model type, but got null");
+                                    return null;
+                                }
+                                modelType = DeserializeImplementation.StringFrom(
+                                    keyValue.Value,
+                                    out error);
+                                if (error != null)
+                                {
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "modelType"));
+                                    return null;
+                                }
+
+                                if (modelType != "File")
+                                {
+                                    error = new Reporting.Error(
+                                        "Expected the model type 'File', " +
+                                        $"but got {modelType}");
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "modelType"));
+                                    return null;
+                                }
+                                break;
+                            }
                         default:
                             error = new Reporting.Error(
                                 $"Unexpected property: {keyValue.Key}");
@@ -8315,6 +8726,13 @@ namespace AasCore.Aas3_0
                 {
                     error = new Reporting.Error(
                         "Required property \"contentType\" is missing");
+                    return null;
+                }
+
+                if (modelType == null)
+                {
+                    error = new Reporting.Error(
+                        "Required property \"modelType\" is missing");
                     return null;
                 }
 
@@ -8365,6 +8783,8 @@ namespace AasCore.Aas3_0
                 List<IQualifier>? theQualifiers = null;
                 List<IEmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
                 List<IDataElement>? theAnnotations = null;
+
+                string? modelType = null;
 
                 foreach (var keyValue in obj)
                 {
@@ -8876,7 +9296,36 @@ namespace AasCore.Aas3_0
                                 break;
                             }
                         case "modelType":
-                            continue;
+                            {
+                                if (keyValue.Value == null)
+                                {
+                                    error = new Reporting.Error(
+                                        "Expected a model type, but got null");
+                                    return null;
+                                }
+                                modelType = DeserializeImplementation.StringFrom(
+                                    keyValue.Value,
+                                    out error);
+                                if (error != null)
+                                {
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "modelType"));
+                                    return null;
+                                }
+
+                                if (modelType != "AnnotatedRelationshipElement")
+                                {
+                                    error = new Reporting.Error(
+                                        "Expected the model type 'AnnotatedRelationshipElement', " +
+                                        $"but got {modelType}");
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "modelType"));
+                                    return null;
+                                }
+                                break;
+                            }
                         default:
                             error = new Reporting.Error(
                                 $"Unexpected property: {keyValue.Key}");
@@ -8895,6 +9344,13 @@ namespace AasCore.Aas3_0
                 {
                     error = new Reporting.Error(
                         "Required property \"second\" is missing");
+                    return null;
+                }
+
+                if (modelType == null)
+                {
+                    error = new Reporting.Error(
+                        "Required property \"modelType\" is missing");
                     return null;
                 }
 
@@ -8949,6 +9405,8 @@ namespace AasCore.Aas3_0
                 List<ISubmodelElement>? theStatements = null;
                 string? theGlobalAssetId = null;
                 List<ISpecificAssetId>? theSpecificAssetIds = null;
+
+                string? modelType = null;
 
                 foreach (var keyValue in obj)
                 {
@@ -9515,7 +9973,36 @@ namespace AasCore.Aas3_0
                                 break;
                             }
                         case "modelType":
-                            continue;
+                            {
+                                if (keyValue.Value == null)
+                                {
+                                    error = new Reporting.Error(
+                                        "Expected a model type, but got null");
+                                    return null;
+                                }
+                                modelType = DeserializeImplementation.StringFrom(
+                                    keyValue.Value,
+                                    out error);
+                                if (error != null)
+                                {
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "modelType"));
+                                    return null;
+                                }
+
+                                if (modelType != "Entity")
+                                {
+                                    error = new Reporting.Error(
+                                        "Expected the model type 'Entity', " +
+                                        $"but got {modelType}");
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "modelType"));
+                                    return null;
+                                }
+                                break;
+                            }
                         default:
                             error = new Reporting.Error(
                                 $"Unexpected property: {keyValue.Key}");
@@ -9527,6 +10014,13 @@ namespace AasCore.Aas3_0
                 {
                     error = new Reporting.Error(
                         "Required property \"entityType\" is missing");
+                    return null;
+                }
+
+                if (modelType == null)
+                {
+                    error = new Reporting.Error(
+                        "Required property \"modelType\" is missing");
                     return null;
                 }
 
@@ -10000,6 +10494,8 @@ namespace AasCore.Aas3_0
                 string? theLastUpdate = null;
                 string? theMinInterval = null;
                 string? theMaxInterval = null;
+
+                string? modelType = null;
 
                 foreach (var keyValue in obj)
                 {
@@ -10600,7 +11096,36 @@ namespace AasCore.Aas3_0
                                 break;
                             }
                         case "modelType":
-                            continue;
+                            {
+                                if (keyValue.Value == null)
+                                {
+                                    error = new Reporting.Error(
+                                        "Expected a model type, but got null");
+                                    return null;
+                                }
+                                modelType = DeserializeImplementation.StringFrom(
+                                    keyValue.Value,
+                                    out error);
+                                if (error != null)
+                                {
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "modelType"));
+                                    return null;
+                                }
+
+                                if (modelType != "BasicEventElement")
+                                {
+                                    error = new Reporting.Error(
+                                        "Expected the model type 'BasicEventElement', " +
+                                        $"but got {modelType}");
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "modelType"));
+                                    return null;
+                                }
+                                break;
+                            }
                         default:
                             error = new Reporting.Error(
                                 $"Unexpected property: {keyValue.Key}");
@@ -10626,6 +11151,13 @@ namespace AasCore.Aas3_0
                 {
                     error = new Reporting.Error(
                         "Required property \"state\" is missing");
+                    return null;
+                }
+
+                if (modelType == null)
+                {
+                    error = new Reporting.Error(
+                        "Required property \"modelType\" is missing");
                     return null;
                 }
 
@@ -10686,6 +11218,8 @@ namespace AasCore.Aas3_0
                 List<IOperationVariable>? theInputVariables = null;
                 List<IOperationVariable>? theOutputVariables = null;
                 List<IOperationVariable>? theInoutputVariables = null;
+
+                string? modelType = null;
 
                 foreach (var keyValue in obj)
                 {
@@ -11259,7 +11793,36 @@ namespace AasCore.Aas3_0
                                 break;
                             }
                         case "modelType":
-                            continue;
+                            {
+                                if (keyValue.Value == null)
+                                {
+                                    error = new Reporting.Error(
+                                        "Expected a model type, but got null");
+                                    return null;
+                                }
+                                modelType = DeserializeImplementation.StringFrom(
+                                    keyValue.Value,
+                                    out error);
+                                if (error != null)
+                                {
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "modelType"));
+                                    return null;
+                                }
+
+                                if (modelType != "Operation")
+                                {
+                                    error = new Reporting.Error(
+                                        "Expected the model type 'Operation', " +
+                                        $"but got {modelType}");
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "modelType"));
+                                    return null;
+                                }
+                                break;
+                            }
                         default:
                             error = new Reporting.Error(
                                 $"Unexpected property: {keyValue.Key}");
@@ -11268,6 +11831,13 @@ namespace AasCore.Aas3_0
                 }
 
 
+
+                if (modelType == null)
+                {
+                    error = new Reporting.Error(
+                        "Required property \"modelType\" is missing");
+                    return null;
+                }
 
                 return new Aas.Operation(
                     theExtensions,
@@ -11381,6 +11951,8 @@ namespace AasCore.Aas3_0
                 List<IReference>? theSupplementalSemanticIds = null;
                 List<IQualifier>? theQualifiers = null;
                 List<IEmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
+
+                string? modelType = null;
 
                 foreach (var keyValue in obj)
                 {
@@ -11789,7 +12361,36 @@ namespace AasCore.Aas3_0
                                 break;
                             }
                         case "modelType":
-                            continue;
+                            {
+                                if (keyValue.Value == null)
+                                {
+                                    error = new Reporting.Error(
+                                        "Expected a model type, but got null");
+                                    return null;
+                                }
+                                modelType = DeserializeImplementation.StringFrom(
+                                    keyValue.Value,
+                                    out error);
+                                if (error != null)
+                                {
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "modelType"));
+                                    return null;
+                                }
+
+                                if (modelType != "Capability")
+                                {
+                                    error = new Reporting.Error(
+                                        "Expected the model type 'Capability', " +
+                                        $"but got {modelType}");
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "modelType"));
+                                    return null;
+                                }
+                                break;
+                            }
                         default:
                             error = new Reporting.Error(
                                 $"Unexpected property: {keyValue.Key}");
@@ -11798,6 +12399,13 @@ namespace AasCore.Aas3_0
                 }
 
 
+
+                if (modelType == null)
+                {
+                    error = new Reporting.Error(
+                        "Required property \"modelType\" is missing");
+                    return null;
+                }
 
                 return new Aas.Capability(
                     theExtensions,
@@ -11839,6 +12447,8 @@ namespace AasCore.Aas3_0
                 IAdministrativeInformation? theAdministration = null;
                 List<IEmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
                 List<IReference>? theIsCaseOf = null;
+
+                string? modelType = null;
 
                 foreach (var keyValue in obj)
                 {
@@ -12216,7 +12826,36 @@ namespace AasCore.Aas3_0
                                 break;
                             }
                         case "modelType":
-                            continue;
+                            {
+                                if (keyValue.Value == null)
+                                {
+                                    error = new Reporting.Error(
+                                        "Expected a model type, but got null");
+                                    return null;
+                                }
+                                modelType = DeserializeImplementation.StringFrom(
+                                    keyValue.Value,
+                                    out error);
+                                if (error != null)
+                                {
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "modelType"));
+                                    return null;
+                                }
+
+                                if (modelType != "ConceptDescription")
+                                {
+                                    error = new Reporting.Error(
+                                        "Expected the model type 'ConceptDescription', " +
+                                        $"but got {modelType}");
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "modelType"));
+                                    return null;
+                                }
+                                break;
+                            }
                         default:
                             error = new Reporting.Error(
                                 $"Unexpected property: {keyValue.Key}");
@@ -12228,6 +12867,13 @@ namespace AasCore.Aas3_0
                 {
                     error = new Reporting.Error(
                         "Required property \"id\" is missing");
+                    return null;
+                }
+
+                if (modelType == null)
+                {
+                    error = new Reporting.Error(
+                        "Required property \"modelType\" is missing");
                     return null;
                 }
 
@@ -13988,6 +14634,8 @@ namespace AasCore.Aas3_0
                 string? theValue = null;
                 ILevelType? theLevelType = null;
 
+                string? modelType = null;
+
                 foreach (var keyValue in obj)
                 {
                     switch (keyValue.Key)
@@ -14374,7 +15022,36 @@ namespace AasCore.Aas3_0
                                 break;
                             }
                         case "modelType":
-                            continue;
+                            {
+                                if (keyValue.Value == null)
+                                {
+                                    error = new Reporting.Error(
+                                        "Expected a model type, but got null");
+                                    return null;
+                                }
+                                modelType = DeserializeImplementation.StringFrom(
+                                    keyValue.Value,
+                                    out error);
+                                if (error != null)
+                                {
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "modelType"));
+                                    return null;
+                                }
+
+                                if (modelType != "DataSpecificationIec61360")
+                                {
+                                    error = new Reporting.Error(
+                                        "Expected the model type 'DataSpecificationIec61360', " +
+                                        $"but got {modelType}");
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "modelType"));
+                                    return null;
+                                }
+                                break;
+                            }
                         default:
                             error = new Reporting.Error(
                                 $"Unexpected property: {keyValue.Key}");
@@ -14386,6 +15063,13 @@ namespace AasCore.Aas3_0
                 {
                     error = new Reporting.Error(
                         "Required property \"preferredName\" is missing");
+                    return null;
+                }
+
+                if (modelType == null)
+                {
+                    error = new Reporting.Error(
+                        "Required property \"modelType\" is missing");
                     return null;
                 }
 

--- a/src/aas-core3.0-csharp.sln.DotSettings.user
+++ b/src/aas-core3.0-csharp.sln.DotSettings.user
@@ -4,7 +4,7 @@
     &lt;TestId&gt;NUnit3x::BDA0E5A2-D48D-4888-9D52-44BD529F8108::net6.0::AasCore.Aas3_0.Tests.TestXmlizationErrors.Test_error_on_unexpected_declaration&lt;/TestId&gt;&#xD;
   &lt;/TestAncestor&gt;&#xD;
 &lt;/SessionState&gt;</s:String>
-	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=bd994a3b_002D4a4e_002D4b0b_002D90d4_002Ddfcb614164d9/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="Test_XML_serialization" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=bd994a3b_002D4a4e_002D4b0b_002D90d4_002Ddfcb614164d9/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" Name="Test_XML_serialization" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
   &lt;Or&gt;&#xD;
     &lt;ProjectFile&gt;BDA0E5A2-D48D-4888-9D52-44BD529F8108/f:TestXmlizationOfConcreteClasses.cs&lt;/ProjectFile&gt;&#xD;
     &lt;ProjectFile&gt;BDA0E5A2-D48D-4888-9D52-44BD529F8108/f:TestXmlizationOfConcreteClassesOutsideContainer.cs&lt;/ProjectFile&gt;&#xD;
@@ -17,12 +17,13 @@
     &lt;/TestAncestor&gt;&#xD;
   &lt;/Or&gt;&#xD;
 &lt;/SessionState&gt;</s:String>
-	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=d08349d0_002D1d79_002D48ae_002D9b89_002D73f1b5254923/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" Name="Test_XML_serialization #2" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=d08349d0_002D1d79_002D48ae_002D9b89_002D73f1b5254923/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="Test_XML_serialization #2" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
   &lt;TestAncestor&gt;&#xD;
     &lt;TestId&gt;NUnit3x::BDA0E5A2-D48D-4888-9D52-44BD529F8108::net6.0::AasCore.Aas3_0.Tests.TestExamples.Test_XML_serialization&lt;/TestId&gt;&#xD;
     &lt;TestId&gt;NUnit3x::BDA0E5A2-D48D-4888-9D52-44BD529F8108::net6.0::AasCore.Aas3_0.Tests.TestExamples.Test_JSON_deserialization&lt;/TestId&gt;&#xD;
     &lt;TestId&gt;NUnit3x::BDA0E5A2-D48D-4888-9D52-44BD529F8108::net6.0::AasCore.Aas3_0.Tests.TestExamples.Test_selective_enhancing&lt;/TestId&gt;&#xD;
     &lt;TestId&gt;NUnit3x::BDA0E5A2-D48D-4888-9D52-44BD529F8108::net6.0::AasCore.Aas3_0.Tests.TestXmlizationErrors.Test_error_on_unexpected_declaration&lt;/TestId&gt;&#xD;
+    &lt;TestId&gt;NUnit3x::BDA0E5A2-D48D-4888-9D52-44BD529F8108::net6.0::AasCore.Aas3_0.Tests.TestJsonizationOfConcreteClasses&lt;/TestId&gt;&#xD;
   &lt;/TestAncestor&gt;&#xD;
 &lt;/SessionState&gt;</s:String>
 	

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/AnnotatedRelationshipElement/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/AnnotatedRelationshipElement/withoutModelType.json
@@ -1,0 +1,31 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "first": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "urn:another-company01:f390f801"
+              }
+            ],
+            "type": "ExternalReference"
+          },
+          "idShort": "something3fdd3eb4",
+          "second": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "urn:an-example05:b7bf2725"
+              }
+            ],
+            "type": "ExternalReference"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/AnnotatedRelationshipElement/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/AnnotatedRelationshipElement/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+Expected a model type, but none is present at: submodels[0].submodelElements[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/AssetAdministrationShell/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/AssetAdministrationShell/withoutModelType.json
@@ -1,0 +1,11 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "NotApplicable",
+        "globalAssetId": "something_eea66fa1"
+      },
+      "id": "something_142922d6"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/AssetAdministrationShell/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/AssetAdministrationShell/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+Required property "modelType" is missing at: assetAdministrationShells[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/BasicEventElement/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/BasicEventElement/withoutModelType.json
@@ -1,0 +1,24 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "direction": "output",
+          "idShort": "something3fdd3eb4",
+          "observed": {
+            "keys": [
+              {
+                "type": "Submodel",
+                "value": "urn:another-example11:3679ef43"
+              }
+            ],
+            "type": "ModelReference"
+          },
+          "state": "off"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/BasicEventElement/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/BasicEventElement/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+Expected a model type, but none is present at: submodels[0].submodelElements[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Blob/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Blob/withoutModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "contentType": "'VbrwFrYTU/fO7NnLxq   \t; \tMX.`10dB732`X5yRy=I56Ov9Us\t ;\t\t pRb~~hdw_C%2Zf=\"\"\t\t\t    \t\t\t \t \t\t \t  ; h=1t",
+          "idShort": "something3fdd3eb4"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Blob/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Blob/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+Expected a model type, but none is present at: submodels[0].submodelElements[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Capability/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Capability/withoutModelType.json
@@ -1,0 +1,13 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Capability/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Capability/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+Expected a model type, but none is present at: submodels[0].submodelElements[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/ConceptDescription/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/ConceptDescription/withoutModelType.json
@@ -1,0 +1,7 @@
+{
+  "conceptDescriptions": [
+    {
+      "id": "something_8ccad77f"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/ConceptDescription/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/ConceptDescription/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+Required property "modelType" is missing at: conceptDescriptions[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/DataSpecificationIec61360/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/DataSpecificationIec61360/withoutModelType.json
@@ -1,0 +1,29 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "NotApplicable",
+        "globalAssetId": "something_eea66fa1"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "i-enochian",
+                "text": "something_84b0b440"
+              },
+              {
+                "language": "en-GB",
+                "text": "Something random in English 5b15c20d"
+              }
+            ],
+            "value": "something_13759f45"
+          }
+        }
+      ],
+      "id": "something_142922d6",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/DataSpecificationIec61360/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/DataSpecificationIec61360/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+Expected a model type, but none is present at: assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Entity/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Entity/withoutModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "entityType": "CoManagedEntity",
+          "idShort": "something3fdd3eb4"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Entity/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Entity/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+Expected a model type, but none is present at: submodels[0].submodelElements[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/File/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/File/withoutModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "contentType": "'VbrwFrYTU/fO7NnLxq   \t; \tMX.`10dB732`X5yRy=I56Ov9Us\t ;\t\t pRb~~hdw_C%2Zf=\"\"\t\t\t    \t\t\t \t \t\t \t  ; h=1t",
+          "idShort": "something3fdd3eb4"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/File/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/File/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+Expected a model type, but none is present at: submodels[0].submodelElements[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/MultiLanguageProperty/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/MultiLanguageProperty/withoutModelType.json
@@ -1,0 +1,13 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/MultiLanguageProperty/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/MultiLanguageProperty/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+Expected a model type, but none is present at: submodels[0].submodelElements[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Operation/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Operation/withoutModelType.json
@@ -1,0 +1,13 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Operation/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Operation/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+Expected a model type, but none is present at: submodels[0].submodelElements[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Property/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Property/withoutModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "valueType": "xs:decimal"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Property/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Property/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+Expected a model type, but none is present at: submodels[0].submodelElements[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Range/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Range/withoutModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "valueType": "xs:decimal"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Range/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Range/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+Expected a model type, but none is present at: submodels[0].submodelElements[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/ReferenceElement/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/ReferenceElement/withoutModelType.json
@@ -1,0 +1,13 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/ReferenceElement/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/ReferenceElement/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+Expected a model type, but none is present at: submodels[0].submodelElements[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/RelationshipElement/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/RelationshipElement/withoutModelType.json
@@ -1,0 +1,31 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "first": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "urn:another-company01:f390f801"
+              }
+            ],
+            "type": "ExternalReference"
+          },
+          "idShort": "something3fdd3eb4",
+          "second": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "urn:an-example05:b7bf2725"
+              }
+            ],
+            "type": "ExternalReference"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/RelationshipElement/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/RelationshipElement/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+Expected a model type, but none is present at: submodels[0].submodelElements[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Submodel/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Submodel/withoutModelType.json
@@ -1,0 +1,7 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Submodel/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Submodel/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+Required property "modelType" is missing at: submodels[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/SubmodelElementCollection/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/SubmodelElementCollection/withoutModelType.json
@@ -1,0 +1,13 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/SubmodelElementCollection/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/SubmodelElementCollection/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+Expected a model type, but none is present at: submodels[0].submodelElements[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/SubmodelElementList/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/SubmodelElementList/withoutModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "typeValueListElement": "Entity"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/SubmodelElementList/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/SubmodelElementList/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+Expected a model type, but none is present at: submodels[0].submodelElements[0]


### PR DESCRIPTION
We explicitly check during the JSON de-serialization that model types correspond to the expected model types. We need to be particularly careful with concrete classes without descendants with a mandatory ``modelType``, as they do not necessarily require a model type for de-serialization, but the specs mandate it for reasons of backward compatibility.

The code corresponds to [aas-core-codegen b537610b], and the test data corresponds to [aas-core3.0-testgen 9e523511c].

This is related to the issue [aas-core3.0-python #32], which discovered the problematic in the first place.

[aas-core-codegen b537610b]: https://github.com/aas-core-works/aas-core-codegen/commit/b537610b
[aas-core3.0-testgen 9e523511c]: https://github.com/aas-core-works/aas-core3.0-testgen/commit/9e523511c
[aas-core3.0-python #32]: https://github.com/aas-core-works/aas-core3.0-python/issues/32