### PR TITLE
Replace test data first in the update script

### DIFF
--- a/dev_scripts/update_to_aas_core_meta_codegen_and_testgen.py
+++ b/dev_scripts/update_to_aas_core_meta_codegen_and_testgen.py
@@ -285,13 +285,13 @@ def _replace_test_data(
 
     print(f"Removing the test data from: {test_data_dir}")
 
-    for pth in [
-        test_data_dir / name
-        for name in ("Descend", "DescendOnce", "Json", "Xml", "XOrDefault")
-    ]:
-        if pth.exists():
-            print(f"Removing {pth} ...")
-            shutil.rmtree(pth)
+    for pth in sorted(
+            sub_pth
+            for sub_pth in test_data_dir.iterdir()
+            if sub_pth.is_dir()
+    ):
+        print(f"Removing {pth} ...")
+        shutil.rmtree(pth)
 
     print(f"Copying the test data from: {aas_core_testgen_repo} ...")
     for pth in [aas_core_testgen_repo / "test_data" / name for name in ("Json", "Xml")]:
@@ -590,11 +590,11 @@ def main() -> int:
         aas_core_codegen_revision=aas_core_codegen_revision,
     )
 
+    _replace_test_data(our_repo=our_repo, aas_core_testgen_repo=aas_core_testgen_repo)
+
     exit_code = _generate_test_code(our_repo=our_repo)
     if exit_code is not None:
         return exit_code
-
-    _replace_test_data(our_repo=our_repo, aas_core_testgen_repo=aas_core_testgen_repo)
 
     _reformat_code(our_repo=our_repo)
 


### PR DESCRIPTION
We need to remove *all* the test data as the specification can introduce breaking changes.

We also need to replace the test data before generating the test code as breaking changes in specification cause the test code generation to fail since it runs a couple of preliminary consistency checks against the test data.