### PR TITLE
Update to aas-core-meta, codegen, testgen 899add1, 4c01ed64, a8c4155e

### DIFF
--- a/dev_scripts/aas_core3/__init__.py
+++ b/dev_scripts/aas_core3/__init__.py
@@ -3,5 +3,5 @@ Provide Python SDK as copied from aas-core-codegen test data.
 
 This copy is necessary so that we can decouple from ``aas-core*-python`` repository.
 
-The revision of aas-core-codegen was: c77b7dc6
+The revision of aas-core-codegen was: 4c01ed64
 """

--- a/dev_scripts/aas_core3/verification.py
+++ b/dev_scripts/aas_core3/verification.py
@@ -7697,7 +7697,9 @@ class _Transformer(
             or (
                 all(
                     not (that.keys[i].type == aas_types.KeyTypes.SUBMODEL_ELEMENT_LIST)
-                    or matches_xs_positive_integer(that.keys[i + 1].value)
+                    or matches_xs_non_negative_integer(
+                        that.keys[i + 1].value
+                    )
                     for i in range(
                         0,
                         len(that.keys) - 1

--- a/dev_scripts/setup.py
+++ b/dev_scripts/setup.py
@@ -28,8 +28,8 @@ setup(
     keywords="asset administration shell code generation industry 4.0 industrie i4.0",
     packages=find_packages(exclude=["tests", "continuous_integration", "dev_scripts"]),
     install_requires=[
-        "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@f2fd738#egg=aas-core-meta",
-        "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@c77b7dc6#egg=aas-core-codegen",
+        "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@899add1#egg=aas-core-meta",
+        "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@4c01ed64#egg=aas-core-codegen",
     ],
     py_modules=["test_codegen"],
 )

--- a/src/AasCore.Aas3_0/copying.cs
+++ b/src/AasCore.Aas3_0/copying.cs
@@ -578,8 +578,8 @@ namespace AasCore.Aas3_0
         internal class DeepCopier : Visitation.AbstractTransformer<Aas.IClass>
         {
             public override Aas.IClass TransformExtension(
-               Aas.IExtension that
-           )
+                Aas.IExtension that
+            )
             {
                 List<IReference>? theSupplementalSemanticIds = null;
                 if (that.SupplementalSemanticIds != null)

--- a/src/AasCore.Aas3_0/verification.cs
+++ b/src/AasCore.Aas3_0/verification.cs
@@ -8892,7 +8892,7 @@ namespace AasCore.Aas3_0
                             that.Keys.Count - 1
                         ).All(
                             i => !(that.Keys[i].Type == KeyTypes.SubmodelElementList)
-                                || Verification.MatchesXsPositiveInteger(that.Keys[i + 1].Value))
+                                || Verification.MatchesXsNonNegativeInteger(that.Keys[i + 1].Value))
                     )))
                 {
                     yield return new Reporting.Error(


### PR DESCRIPTION
We update the development requirements to and re-generate everything with:
* [aas-core-meta 899add1],
* [aas-core-codegen 4c01ed64] and
* [aas-core3.0-testgen a8c4155e].

Notably, this propagates a fix for references index constraint where
indices in references were erroneously assumed to be positive integers.

[aas-core-meta 899add1]: https://github.com/aas-core-works/aas-core-meta/commit/899add1
[aas-core-codegen 4c01ed64]: https://github.com/aas-core-works/aas-core-codegen/commit/4c01ed64
[aas-core3.0-testgen a8c4155e]: https://github.com/aas-core-works/aas-core3.0-testgen/commit/a8c4155e