### PR TITLE
Release 1.0.5

### DIFF
--- a/doc/source/change_log.md
+++ b/doc/source/change_log.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 1.0.5 (2025-10-20)
+
+This is a patch release that propagates a fix for references index constraint
+where indices in references were erroneously assumed to be positive integers.
+
 ## 1.0.4 (2025-04-29)
 
 We propagate the changes and fixes for V3.0.2; please refer to:

--- a/src/AasCore.Aas3_0/AasCore.Aas3_0.csproj
+++ b/src/AasCore.Aas3_0/AasCore.Aas3_0.csproj
@@ -7,7 +7,7 @@
     <LangVersion>8</LangVersion>
 
     <PackageId>AasCore.Aas3_0</PackageId>
-    <Version>1.0.4</Version>
+    <Version>1.0.5</Version>
     <Authors>Marko Ristin</Authors>
     <Description>
         An SDK for manipulating, verifying and de/serializing Asset Administration Shells.


### PR DESCRIPTION
Propagate a fix for references index constraint where indices in references were
erroneously assumed to be positive integers.