### PR TITLE
Bump Doc Build Runner to windows-2022

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:
+  # We need to manually run the workflow for debugging purposes. 
+  workflow_dispatch: 
 
 jobs:
   Generate-doc:


### PR DESCRIPTION
Building docs fails as the windows-2019 runner has been deprecated. Update the
runner to the next stable version (windows-2022).