### PR TITLE
Adapt dev_scripts for new source layout in aas-core-codegen

### DIFF
--- a/dev_scripts/update_to_aas_core_meta_codegen_and_testgen.py
+++ b/dev_scripts/update_to_aas_core_meta_codegen_and_testgen.py
@@ -126,7 +126,7 @@ def _copy_code_from_aas_core_codegen(
     """Copy the generated code from aas-core-codegen's test data."""
     source_dir = (
         aas_core_codegen_repo
-        / "test_data/csharp/test_main/aas_core_meta.v3/expected_output"
+        / "dev/test_data/csharp/test_main/aas_core_meta.v3/expected_output"
     )
 
     target_dir = our_repo / "src/AasCore.Aas3_0"
@@ -150,7 +150,7 @@ def _copy_python_sdk_from_aas_core_codegen(
     """Copy the generated Python SDK from aas-core-codegen's test data."""
     source_dir = (
         aas_core_codegen_repo
-        / "test_data/python/test_main/aas_core_meta.v3/expected_output"
+        / "dev/test_data/python/test_main/aas_core_meta.v3/expected_output"
     )
 
     target_dir = our_repo / "dev_scripts/aas_core3"


### PR DESCRIPTION
With [aas-core-codegen 79d7b79] the place where snippets are stored has changed. We adapt the code generation scripts accordingly.

[aas-core-codegen 79d7b79]: https://github.com/aas-core-works/aas-core-codegen/commit/79d7b790bdb652155c0fa33fa2fd0f5e70bc3ae9